### PR TITLE
fix bug: manage call screen still show holding when user cancel transfer then resume call 

### DIFF
--- a/src/stores/Call.ts
+++ b/src/stores/Call.ts
@@ -197,7 +197,7 @@ export class Call {
   @action stopTransferring = () => {
     this.prevTransferring = this.transferring
     this.transferring = ''
-    // when user cancel transfer and resume call, server will auto unhold. So, update holding = false
+    // user cancel transfer and resume call => auto unhold
     this.prevHoling = this.holding
     this.holding = false
     return pbx

--- a/src/stores/Call.ts
+++ b/src/stores/Call.ts
@@ -134,6 +134,8 @@ export class Call {
   }
 
   @observable holding = false
+  private prevHoling = false
+
   @action private toggleHold = () => {
     const fn = this.holding ? pbx.unholdTalker : pbx.holdTalker
     this.holding = !this.holding
@@ -196,6 +198,7 @@ export class Call {
     this.prevTransferring = this.transferring
     this.transferring = ''
     // when user cancel transfer and resume call, server will auto unhold. So, update holding = false
+    this.prevHoling = this.holding
     this.holding = false
     return pbx
       .stopTalkerTransfer(this.pbxTenant, this.pbxTalkerId)
@@ -203,6 +206,7 @@ export class Call {
   }
   @action private onStopTransferringFailure = (err: Error) => {
     this.transferring = this.prevTransferring
+    this.holding = this.prevHoling
     RnAlert.error({
       message: intlDebug`Failed to stop the transfer`,
       err,

--- a/src/stores/Call.ts
+++ b/src/stores/Call.ts
@@ -195,6 +195,8 @@ export class Call {
   @action stopTransferring = () => {
     this.prevTransferring = this.transferring
     this.transferring = ''
+    // when user cancel transfer and resume call, server will auto unhold. So, update holding = false
+    this.holding = false
     return pbx
       .stopTalkerTransfer(this.pbxTenant, this.pbxTalkerId)
       .catch(this.onStopTransferringFailure)

--- a/src/stores/Call.ts
+++ b/src/stores/Call.ts
@@ -197,7 +197,7 @@ export class Call {
   @action stopTransferring = () => {
     this.prevTransferring = this.transferring
     this.transferring = ''
-    // user cancel transfer and resume call => auto unhold
+    // User cancel transfer and resume call -> unhold automatically from server side
     this.prevHoling = this.holding
     this.holding = false
     return pbx


### PR DESCRIPTION
fix bug: #309: https://docs.google.com/spreadsheets/d/1QFhIXrNigY37xds98kdfbbSiqHoBj2RC/edit#gid=741052244&range=210:210