### PR TITLE
#4: Remove display phone on UserItem

### DIFF
--- a/src/components/ContactUserItem.tsx
+++ b/src/components/ContactUserItem.tsx
@@ -9,7 +9,7 @@ import { StyleSheet, View } from 'react-native'
 
 import { Conference } from '../api/brekekejs'
 import { Constants, uc } from '../api/uc'
-import { contactStore } from '../stores/contactStore'
+import { getPartyName } from '../stores/addCallHistory'
 import { intl, intlDebug } from '../stores/intl'
 import { Nav } from '../stores/Nav'
 import { RnAlert } from '../stores/RnAlert'
@@ -162,10 +162,10 @@ export const UserItem: FC<
       iconFuncs?.[i]?.()
     }
   }
-  const template = name || partyName || partyNumber || id
-  // check phone exists inside contacts to display origin name
-  const displayName =
-    contactStore.getPhoneBookByPhoneNumber(template)?.name || template
+
+  // Check phone exists inside contacts to display origin name
+  const partyName2 = getPartyName(partyNumber)
+  const displayName = partyName2 || partyName || name || partyNumber || id
 
   return (
     <Container style={css.Outer} onPress={onPressItem}>

--- a/src/components/ContactUserItem.tsx
+++ b/src/components/ContactUserItem.tsx
@@ -9,6 +9,7 @@ import { StyleSheet, View } from 'react-native'
 
 import { Conference } from '../api/brekekejs'
 import { Constants, uc } from '../api/uc'
+import { contactStore } from '../stores/contactStore'
 import { intl, intlDebug } from '../stores/intl'
 import { Nav } from '../stores/Nav'
 import { RnAlert } from '../stores/RnAlert'
@@ -161,6 +162,10 @@ export const UserItem: FC<
       iconFuncs?.[i]?.()
     }
   }
+  const template = name || partyName || partyNumber || id
+  // check phone exists inside contacts to display origin name
+  const displayName =
+    contactStore.getPhoneBookByPhoneNumber(template)?.name || template
 
   return (
     <Container style={css.Outer} onPress={onPressItem}>
@@ -184,7 +189,7 @@ export const UserItem: FC<
         <View style={[css.Text, css.WithSpace]}>
           <View style={css.NameWithStatus}>
             <RnText black bold singleLine>
-              {name || partyName}
+              {displayName}
             </RnText>
             {!!statusText && (
               <RnText normal singleLine small style={css.Status}>

--- a/src/components/ContactUserItem.tsx
+++ b/src/components/ContactUserItem.tsx
@@ -184,7 +184,7 @@ export const UserItem: FC<
         <View style={[css.Text, css.WithSpace]}>
           <View style={css.NameWithStatus}>
             <RnText black bold singleLine>
-              {name || partyName || partyNumber || id}
+              {name || partyName}
             </RnText>
             {!!statusText && (
               <RnText normal singleLine small style={css.Status}>

--- a/src/stores/addCallHistory.ts
+++ b/src/stores/addCallHistory.ts
@@ -4,6 +4,7 @@ import { v4 as newUuid } from 'uuid'
 import { ParsedPn } from '../utils/PushNotification-parse'
 import { getAuthStore } from './authStore'
 import { Call } from './Call'
+import { contactStore } from './contactStore'
 
 const alreadyAddHistoryMap: { [pnId: string]: true } = {}
 export const addCallHistory = (c: Call | ParsedPn) => {
@@ -24,7 +25,7 @@ export const addCallHistory = (c: Call | ParsedPn) => {
       created,
       incoming: c.incoming,
       answered: c.answered,
-      partyName: c.partyName,
+      partyName: c.partyName || getPartyName(c.partyNumber) || c.partyNumber,
       partyNumber: c.partyNumber,
       duration: c.getDuration(),
     })
@@ -34,9 +35,13 @@ export const addCallHistory = (c: Call | ParsedPn) => {
       created,
       incoming: true,
       answered: false,
-      partyName: c.from,
+      partyName: getPartyName(c.from) || c.from,
       partyNumber: c.from,
       duration: 0,
     })
   }
 }
+
+export const getPartyName = (partyNumber?: string) =>
+  (partyNumber && contactStore.getPbxUserById(partyNumber)?.name) ||
+  contactStore.getPhoneBookByPhoneNumber(partyNumber)?.name

--- a/src/stores/contactStore.ts
+++ b/src/stores/contactStore.ts
@@ -164,6 +164,18 @@ class ContactStore {
       [k: string]: Phonebook2
     }
   }
+
+  getPhoneBookByPhoneNumber = (phoneNumber?: string) => {
+    if (!phoneNumber) {
+      return
+    }
+    return this.phoneBooks.filter(
+      p =>
+        p.cellNumber === phoneNumber ||
+        p.homeNumber === phoneNumber ||
+        p.workNumber === phoneNumber,
+    )?.[0]
+  }
   getPhonebookById = (id: string) => {
     return this.phoneBooksMap[id]
   }


### PR DESCRIPTION
#4: When making a call from the history (or wherever), the record of the history of the new call shows as a phone number.
  So please somehow show the original display name.