### PR TITLE
Fix no voice when make call with disable PN

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -112,7 +112,6 @@ PushNotification.register(() => {
   const s = getAuthStore()
   alreadyInitApp = true
 
-  setupCallKeep()
   profileStore.loadProfilesFromLocalStorage().then(() => {
     if (AppState.currentState === 'active') {
       SyncPnToken().syncForAllAccounts()
@@ -206,7 +205,9 @@ export const App = observer(() => {
   if (failure && ucLoginFromAnotherPlace) {
     connMessage = intl`UC signed in from another location`
   }
-
+  setTimeout(() => {
+    setupCallKeep()
+  }, 500)
   return (
     <View style={[StyleSheet.absoluteFill, css.App]}>
       <RnStatusBar />


### PR DESCRIPTION
Bug:
- ios PN disabled, app opening foreground - receive call+answer gsm first, then incoming brekeke call -> failed: no voice connected
- ios receive call+answer gsm first, then outgoing brekeke call (PN setting not relevant in this case of outgoing call) -> failed: no voice connected