### PR TITLE
Fix no voice with PN disable 

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -365,7 +365,7 @@ PODS:
     - React-Core
   - ReactNativeIncallManager (3.3.0-brekeke-002):
     - React
-  - RNCallKeep (4.2.0-brekeke-005):
+  - RNCallKeep (4.2.0-brekeke-006):
     - React
   - RNCAsyncStorage (1.15.8):
     - React-Core
@@ -632,7 +632,7 @@ SPEC CHECKSUMS:
   ReactCommon: eafed38eec7b591c31751bfa7494801618460459
   ReactNativeExceptionHandler: b11ff67c78802b2f62eed0e10e75cb1ef7947c60
   ReactNativeIncallManager: b88d8fea6f88f26b926ee755d2c396ebb76da438
-  RNCallKeep: 22f7bb37b0529a87dd83910ac4e8b3204fa3b824
+  RNCallKeep: 5f15d2220be70d89381c696a99894fdb34b2aaae
   RNCAsyncStorage: e8b8d6320a0dd90eb610fb0d0b1ef90596697c69
   RNCPushNotificationIOS: 87b8d16d3ede4532745e05b03c42cff33a36cc45
   RNFastImage: 1f2cab428712a4baaf78d6169eaec7f622556dd7

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-dom": "17.0.2",
     "react-native": "0.65.1",
     "react-native-background-timer": "2.4.1",
-    "react-native-callkeep": "github:brekekesoftware/react-native-callkeep#d9094da1945c8afd3877a312b8ef0eae623ebd0a",
+    "react-native-callkeep": "github:brekekesoftware/react-native-callkeep#eeb67e1426a16f92ead2d2028fd0132244b990c1",
     "react-native-document-picker": "4.3.0",
     "react-native-emoji-selector": "0.2.0",
     "react-native-exception-handler": "2.10.10",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-dom": "17.0.2",
     "react-native": "0.65.1",
     "react-native-background-timer": "2.4.1",
-    "react-native-callkeep": "github:brekekesoftware/react-native-callkeep#eeb67e1426a16f92ead2d2028fd0132244b990c1",
+    "react-native-callkeep": "github:brekekesoftware/react-native-callkeep#87d5fcc1a3ca7f809521f9890bc294da3feda6b5",
     "react-native-document-picker": "4.3.0",
     "react-native-emoji-selector": "0.2.0",
     "react-native-exception-handler": "2.10.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10815,9 +10815,9 @@ react-native-background-timer@2.4.1:
   resolved "https://registry.yarnpkg.com/react-native-background-timer/-/react-native-background-timer-2.4.1.tgz#a3bc1cafa8c1e3aeefd0611de120298b67978a0f"
   integrity sha512-TE4Kiy7jUyv+hugxDxitzu38sW1NqjCk4uE5IgU2WevLv7sZacaBc6PZKOShNRPGirLl1NWkaG3LDEkdb9Um5g==
 
-"react-native-callkeep@github:brekekesoftware/react-native-callkeep#d9094da1945c8afd3877a312b8ef0eae623ebd0a":
-  version "4.2.0-brekeke-005"
-  resolved "https://codeload.github.com/brekekesoftware/react-native-callkeep/tar.gz/d9094da1945c8afd3877a312b8ef0eae623ebd0a"
+"react-native-callkeep@github:brekekesoftware/react-native-callkeep#eeb67e1426a16f92ead2d2028fd0132244b990c1":
+  version "4.2.0-brekeke-006"
+  resolved "https://codeload.github.com/brekekesoftware/react-native-callkeep/tar.gz/eeb67e1426a16f92ead2d2028fd0132244b990c1"
 
 react-native-codegen@0.0.8:
   version "0.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10815,9 +10815,9 @@ react-native-background-timer@2.4.1:
   resolved "https://registry.yarnpkg.com/react-native-background-timer/-/react-native-background-timer-2.4.1.tgz#a3bc1cafa8c1e3aeefd0611de120298b67978a0f"
   integrity sha512-TE4Kiy7jUyv+hugxDxitzu38sW1NqjCk4uE5IgU2WevLv7sZacaBc6PZKOShNRPGirLl1NWkaG3LDEkdb9Um5g==
 
-"react-native-callkeep@github:brekekesoftware/react-native-callkeep#eeb67e1426a16f92ead2d2028fd0132244b990c1":
+"react-native-callkeep@github:brekekesoftware/react-native-callkeep#87d5fcc1a3ca7f809521f9890bc294da3feda6b5":
   version "4.2.0-brekeke-006"
-  resolved "https://codeload.github.com/brekekesoftware/react-native-callkeep/tar.gz/eeb67e1426a16f92ead2d2028fd0132244b990c1"
+  resolved "https://codeload.github.com/brekekesoftware/react-native-callkeep/tar.gz/87d5fcc1a3ca7f809521f9890bc294da3feda6b5"
 
 react-native-codegen@0.0.8:
   version "0.0.8"


### PR DESCRIPTION
Bug:
+ ios PN disabled, app opening foreground - receive call+answer gsm first, then incoming brekeke call -> failed: no voice connected
 + ios receive call+answer gsm first, then outgoing brekeke call (PN setting not relevant in this case of outgoing call) -> failed: no voice connected
Fix:
- add `initCallKitProvider` to 'startCall' RNcallkeep  