### PR TITLE
Fix: Mix voice when answer outgoing call while talking via GSM call 

### DIFF
--- a/src/stores/callStore.ts
+++ b/src/stores/callStore.ts
@@ -152,7 +152,7 @@ export class CallStore {
     const cExisting = this.calls.find(c => c.id === cPartial.id)
     if (cExisting) {
       if (!cExisting.answered && cPartial.answered) {
-        cExisting.answerCallKeep()
+        Platform.OS !== 'web' && cExisting.answerCallKeep()
         cPartial.answeredAt = now
       }
       Object.assign(cExisting, cPartial)
@@ -276,7 +276,8 @@ export class CallStore {
       Platform.OS !== 'web'
     ) {
       uuid = newUuid().toUpperCase()
-      RNCallKeep.startCall(uuid, number, 'Brekeke Phone')
+      Platform.OS === 'ios' &&
+        RNCallKeep.startCall(uuid, number, 'Brekeke Phone')
       this.setAutoEndCallKeepTimer(uuid)
     }
     // Check for each 0.5s: auto update currentCallId


### PR DESCRIPTION
Reproduce:
1. Login brekeke phone
2. The brekeke phone makes an outgoing call
3. While brekeke is dialling makes an incoming GSM call to the brekeke phone's device
=> The GSM call appears at the top of phone screen.
4. Pick up the GSM call first.
=> The GSM call is connected and talking well
The Brekeke cal keep dialling
5. Pickup the Brekeke call (from others on Brekeke phone)
=>  the Brekeke call is connected with voice.
The GSM call is still talking well. But mix voice from Brekeke call

Solution:
Move Callkeep.startCall to answer function for Android
