### PR TITLE
Fix: alway disappear PN when receive brekeke call

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/BrekekeModule.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/BrekekeModule.java
@@ -215,10 +215,9 @@ public class BrekekeModule extends ReactContextBaseJavaModule {
             }
           }
         };
+
     // Try to run it as it does not display multiple calls via on onShowIncomingCallUi
-    if (VoiceConnectionService.currentConnections.size() > 0
-        || RNCallKeepModule.fcmCallbacks.size() > 0
-        || activitiesSize > 0) {
+    if (VoiceConnectionService.currentConnections.size() > 0) {
       r.run();
     }
     RNCallKeepModule.fcmCallbacks.put(uuid, r);


### PR DESCRIPTION
Produce:
- Kill app And lock screen 
- Make GSM call 
- Make brekeke call when PN GSM  ring ring 
- GSM call disconnect 
- end  brekeke call
- make brekeke call again 
=> PN incoming call not show 
