### PR TITLE
 Fix ringtone don't play via devices connected bluetooth

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
   <uses-permission
     android:name="android.permission.BIND_TELECOM_CONNECTION_SERVICE"
   />
+  <uses-permission android:name="android.permission.BLUETOOTH" />
   <uses-permission android:name="android.permission.CALL_PHONE" />
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />


### PR DESCRIPTION
**Issue**: App issues while Bluetooth is connected to android:

- **When calling from android to Iphone**

1. Calling ringtone is not heard in Bluetooth or Android phone
2. Voice sometimes comes from Android phone instead of Bluetooth device,
and sometimes it comes from Bluetooth device but delay will be there in
audio.

- **When calling from Iphone to android**

1. Ringtone is heard in Bluetooth device but when call is accepted voice
will come from Android device instead of Bluetooth.
