### PR TITLE
Fix double hold call with case outgoing call

### DIFF
--- a/src/stores/callStore.ts
+++ b/src/stores/callStore.ts
@@ -162,6 +162,7 @@ export class CallStore {
         delete cPartial.remoteVideoStreamObject
       }
       if (!cExisting.answered && cPartial.answered) {
+        this.currentCallId = cExisting.id
         cExisting.answerCallKeep()
         cPartial.answeredAt = now
       }


### PR DESCRIPTION
**Issue**: 
1. Call from 2002 to 2004.
2. While 2002 is sending, 2017 will send to 2002.
3. Answer incoming calls from 2017.
4. 2004 answers during a call with 2017.
5. Calls to 2017 will be put on hold, but calls to 2004 will also be put on hold.
The action that should be taken is "The call with 2017 will be put on hold and the call with 2004 will be established."
