### PR TITLE
fix bug click misscall notification, app can not navigate to page r…

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -116,8 +116,10 @@
       android:exported="true"
     >
       <intent-filter>
+        <action android:name="MissedCallNotification" />
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
+        <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <!-- deep link -->
       <intent-filter>

--- a/android/app/src/main/java/com/brekeke/phonedev/MainActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/MainActivity.java
@@ -1,6 +1,7 @@
 package com.brekeke.phonedev;
 
 import android.content.Intent;
+import android.os.Bundle;
 import androidx.annotation.NonNull;
 import com.facebook.react.ReactActivity;
 import io.wazo.callkeep.RNCallKeepModule;
@@ -22,6 +23,17 @@ public class MainActivity extends ReactActivity {
   public void onBackPressed() {
     // Do not exit on back pressed
     BrekekeModule.emit("onBackPressed", "");
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    Bundle extras = getIntent().getExtras();
+    if (extras != null
+        && extras.get("id") != null
+        && extras.get("id").toString().startsWith("missedcall")) {
+      BrekekeModule.emit("onGoToPageRecentCall", "");
+    }
   }
 
   @Override

--- a/src/stores/addCallHistory.ts
+++ b/src/stores/addCallHistory.ts
@@ -77,6 +77,7 @@ const presentNotification = (c: {
   const body = c.partyName || c.partyNumber
   if (Platform.OS === 'android') {
     FCM.presentLocalNotification({
+      click_action: 'MissedCallNotification',
       title,
       body,
       number: 0,

--- a/src/utils/callkeep.ts
+++ b/src/utils/callkeep.ts
@@ -258,6 +258,9 @@ export const setupCallKeep = async () => {
     })
     // Other utils
     eventEmitter.addListener('onBackPressed', onBackPressed)
+    eventEmitter.addListener('onGoToPageRecentCall', () => {
+      Nav().goToPageCallRecents()
+    })
     eventEmitter.addListener('debug', (m: string) =>
       console.error(`Android debug: ${m}`),
     )


### PR DESCRIPTION
-Issue:
When click to missed call notification, app can not navigate to page recents call 