### PR TITLE
- fix: ringtone can not stop

### DIFF
--- a/src/components/CallNotify.tsx
+++ b/src/components/CallNotify.tsx
@@ -8,6 +8,7 @@ import { getAuthStore } from '../stores/authStore'
 import { callStore } from '../stores/callStore'
 import { intl } from '../stores/intl'
 import { Nav } from '../stores/Nav'
+import { RnAppState } from '../stores/RnAppState'
 import { RnStacker } from '../stores/RnStacker'
 import { BackgroundTimer } from '../utils/BackgroundTimer'
 import { ButtonIcon } from './ButtonIcon'
@@ -66,7 +67,11 @@ export const CallNotify = observer(() => {
   const c = callStore.getCallInNotify()
   // Do not show notify if in page call manage
   const s = RnStacker.stacks[RnStacker.stacks.length - 1]
-  if (s?.name === 'PageCallManage' || !c) {
+  if (
+    s?.name === 'PageCallManage' ||
+    !c ||
+    RnAppState.currentState !== 'active'
+  ) {
     return null
   }
   const k = callStore.callkeepMap[c.callkeepUuid]

--- a/src/components/CallNotify.tsx
+++ b/src/components/CallNotify.tsx
@@ -8,7 +8,6 @@ import { getAuthStore } from '../stores/authStore'
 import { callStore } from '../stores/callStore'
 import { intl } from '../stores/intl'
 import { Nav } from '../stores/Nav'
-import { RnAppState } from '../stores/RnAppState'
 import { RnStacker } from '../stores/RnStacker'
 import { BackgroundTimer } from '../utils/BackgroundTimer'
 import { ButtonIcon } from './ButtonIcon'
@@ -67,11 +66,7 @@ export const CallNotify = observer(() => {
   const c = callStore.getCallInNotify()
   // Do not show notify if in page call manage
   const s = RnStacker.stacks[RnStacker.stacks.length - 1]
-  if (
-    s?.name === 'PageCallManage' ||
-    !c ||
-    RnAppState.currentState !== 'active'
-  ) {
+  if (s?.name === 'PageCallManage' || !c) {
     return null
   }
   const k = callStore.callkeepMap[c.callkeepUuid]

--- a/src/components/CallVoicesUI.tsx
+++ b/src/components/CallVoicesUI.tsx
@@ -11,7 +11,6 @@ export class IncomingItem extends Component {
     if (Platform.OS === 'android' && (await BrekekeUtils.isSilent())) {
       return
     }
-    console.log('IncomingItem -> start rington')
     IncallManager.startRingtone('_BUNDLE_')
     this.ringtonePlaying = true
     // TODO stop ringtone if user press hardware button

--- a/src/components/CallVoicesUI.tsx
+++ b/src/components/CallVoicesUI.tsx
@@ -11,16 +11,15 @@ export class IncomingItem extends Component {
     if (Platform.OS === 'android' && (await BrekekeUtils.isSilent())) {
       return
     }
+    console.log('IncomingItem -> start rington')
     IncallManager.startRingtone('_BUNDLE_')
     this.ringtonePlaying = true
     // TODO stop ringtone if user press hardware button
     // https://www.npmjs.com/package/react-native-keyevent
   }
   componentWillUnmount() {
-    if (this.ringtonePlaying) {
-      IncallManager.stopRingtone()
-      this.ringtonePlaying = false
-    }
+    IncallManager.stopRingtone()
+    this.ringtonePlaying = false
     if (Platform.OS === 'android') {
       // Bug speaker auto turn on after call stopRingtone/stopRingback
       IncallManager.setForceSpeakerphoneOn(callStore.isLoudSpeakerEnabled)

--- a/src/stores/RnAppState.ts
+++ b/src/stores/RnAppState.ts
@@ -1,5 +1,6 @@
 import { action, observable } from 'mobx'
 import { AppState } from 'react-native'
+import IncallManager from 'react-native-incall-manager'
 
 class RnAppStateStore {
   @observable currentState = AppState.currentState
@@ -8,6 +9,9 @@ class RnAppStateStore {
       'change',
       action(() => {
         this.currentState = AppState.currentState
+        if (this.currentState !== 'active') {
+          IncallManager.stopRingtone()
+        }
       }),
     )
   }

--- a/src/stores/RnAppState.ts
+++ b/src/stores/RnAppState.ts
@@ -1,17 +1,13 @@
 import { action, observable } from 'mobx'
 import { AppState } from 'react-native'
-import IncallManager from 'react-native-incall-manager'
 
 class RnAppStateStore {
   @observable currentState = AppState.currentState
   constructor() {
     AppState.addEventListener(
       'change',
-      action(() => {
-        this.currentState = AppState.currentState
-        if (this.currentState !== 'active') {
-          IncallManager.stopRingtone()
-        }
+      action(nextAppState => {
+        this.currentState = nextAppState
       }),
     )
   }


### PR DESCRIPTION
After turning off the manner mode, putting the Brekeke Phone in the background and locking it, if you cancel the incoming call to the Brekeke Phone, only the ringtone does not stop.
It stops when the Brekeke Phone process is terminated.
It occurs in android10 and does not occur in android11.
【procedure】
1. Start BrekekePhone from the absence of the BrekekePhone process and sign in.
2. Press the ○ button to put the Brekeke Phone in the background and then lock the device.
3. Make a call from 2004 to 2002 and receive a Brekeke Phone.
4. 2004 cancels the call.
5. In 2002, the incoming call screen disappears, the vibration stops and the idle state is set, but only the ringtone does not stop.