### PR TITLE
- add action press to move page manage call

### DIFF
--- a/src/components/CallNotify.tsx
+++ b/src/components/CallNotify.tsx
@@ -79,14 +79,14 @@ export const CallNotify = observer(() => {
   return (
     <Wrapper>
       {callStore.shouldRingInNotify(c.callkeepUuid) && <IncomingItem />}
-      <View style={css.Notify}>
-        <RnTouchableOpacity
-          onPress={() => Nav().goToPageCallManage()}
-          style={css.Notify_Info}
-        >
+      <RnTouchableOpacity
+        style={css.Notify}
+        onPress={() => Nav().goToPageCallManage()}
+      >
+        <View style={css.Notify_Info}>
           <RnText bold>{c.computedName}</RnText>
           <RnText>{intl`Incoming Call`}</RnText>
-        </RnTouchableOpacity>
+        </View>
         <ButtonIcon
           bdcolor={v.colors.danger}
           color={v.colors.danger}
@@ -103,7 +103,7 @@ export const CallNotify = observer(() => {
           size={20}
           style={css.Notify_Btn_accept}
         />
-      </View>
+      </RnTouchableOpacity>
     </Wrapper>
   )
 })

--- a/src/components/CallNotify.tsx
+++ b/src/components/CallNotify.tsx
@@ -7,11 +7,12 @@ import { mdiCheck, mdiClose } from '../assets/icons'
 import { getAuthStore } from '../stores/authStore'
 import { callStore } from '../stores/callStore'
 import { intl } from '../stores/intl'
+import { Nav } from '../stores/Nav'
 import { RnStacker } from '../stores/RnStacker'
 import { BackgroundTimer } from '../utils/BackgroundTimer'
 import { ButtonIcon } from './ButtonIcon'
 import { IncomingItem } from './CallVoicesUI'
-import { RnText } from './Rn'
+import { RnText, RnTouchableOpacity } from './Rn'
 import { v } from './variables'
 
 const css = StyleSheet.create({
@@ -79,10 +80,13 @@ export const CallNotify = observer(() => {
     <Wrapper>
       {callStore.shouldRingInNotify(c.callkeepUuid) && <IncomingItem />}
       <View style={css.Notify}>
-        <View style={css.Notify_Info}>
+        <RnTouchableOpacity
+          onPress={() => Nav().goToPageCallManage()}
+          style={css.Notify_Info}
+        >
           <RnText bold>{c.computedName}</RnText>
           <RnText>{intl`Incoming Call`}</RnText>
-        </View>
+        </RnTouchableOpacity>
         <ButtonIcon
           bdcolor={v.colors.danger}
           color={v.colors.danger}


### PR DESCRIPTION
It does not display multiple incoming calls after brekeke phone try to pickup the call just canceled.
**Issue**:
1. Make 3 incoming calls to brekeke phone following oders: 101, 102, 103
2. the last one 103 rings and displays on top of the brekeke phone's screen.
3. 103 cancels and the brekeke phone try to pickup the call at the same time.
=> The call is disconnected, But it shows a screen like
current list -> 102 is ringing
background list -> 101 is riniging
4. The brekeke phone try to select arrow button to move to main screen of the phone.
=> Actual: Now, it just shows only one call (102) on Call bar, and cannot move change back to background list anymore.
Expected: It can change back the screen to see background list.
5. Press Disconnected, 
=> Actual: the call 102 is disconnected. It does not display remaing call (101), while 101 keep dialing status.