### PR TITLE
Contact display name

### DIFF
--- a/src/api/brekekejs.d.ts
+++ b/src/api/brekekejs.d.ts
@@ -213,6 +213,7 @@ export type PbxContact = {
   info: {
     $firstname: string
     $lastname: string
+    $displayname: string
     $tel_work: string
     $tel_home: string
     $tel_mobile: string

--- a/src/api/brekekejs.d.ts
+++ b/src/api/brekekejs.d.ts
@@ -210,10 +210,10 @@ export type PbxContact = {
   aid: string
   phonebook: string
   shared: string
+  display_name: string
   info: {
     $firstname: string
     $lastname: string
-    $displayname: string
     $tel_work: string
     $tel_home: string
     $tel_mobile: string

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -331,6 +331,7 @@ export class PBX extends EventEmitter {
       id,
       firstName: res.info.$firstname,
       lastName: res.info.$lastname,
+      displayName: res.info.$displayname,
       workNumber: res.info.$tel_work,
       homeNumber: res.info.$tel_home,
       cellNumber: res.info.$tel_mobile,
@@ -350,6 +351,8 @@ export class PBX extends EventEmitter {
     shared: boolean
     firstName: string
     lastName: string
+    name: string
+    displayName?: string
     workNumber: string
     homeNumber: string
     cellNumber: string
@@ -373,6 +376,7 @@ export class PBX extends EventEmitter {
       info: {
         $firstname: contact.firstName,
         $lastname: contact.lastName,
+        $displayname: contact.displayName || contact.name,
         $tel_work: contact.workNumber,
         $tel_home: contact.homeNumber,
         $tel_mobile: contact.cellNumber,

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -331,7 +331,7 @@ export class PBX extends EventEmitter {
       id,
       firstName: res.info.$firstname,
       lastName: res.info.$lastname,
-      displayName: res.info.$displayname,
+      displayName: res.display_name,
       workNumber: res.info.$tel_work,
       homeNumber: res.info.$tel_home,
       cellNumber: res.info.$tel_mobile,
@@ -372,11 +372,10 @@ export class PBX extends EventEmitter {
       aid: contact.id,
       phonebook: contact.book,
       shared: contact.shared ? 'true' : 'false',
-
+      display_name: contact.displayName,
       info: {
         $firstname: contact.firstName,
         $lastname: contact.lastName,
-        $displayname: contact.displayName || contact.name,
         $tel_work: contact.workNumber,
         $tel_home: contact.homeNumber,
         $tel_mobile: contact.cellNumber,

--- a/src/pages/PageContactPhonebook.tsx
+++ b/src/pages/PageContactPhonebook.tsx
@@ -70,7 +70,7 @@ export class PageContactPhonebook extends Component {
         const x = {
           ...ct,
           loaded: true,
-          name: ct.firstName + ' ' + ct.lastName,
+          name: ct.displayName || ct.firstName + ' ' + ct.lastName,
           hidden: ct.hidden === 'true',
         }
         contactStore.upsertPhonebook(x)
@@ -234,7 +234,7 @@ export class PageContactPhonebook extends Component {
                   iconFuncs={[() => this.onIcon0(u), () => this.update(u.id)]}
                   icons={[mdiPhone, mdiInformation]}
                   key={i}
-                  name={u.name}
+                  name={u.displayName || u.name}
                 />
               ))}
             </Fragment>

--- a/src/pages/PagePhonebookCreate.tsx
+++ b/src/pages/PagePhonebookCreate.tsx
@@ -37,7 +37,9 @@ export class PagePhonebookCreate extends Component<{
         }
         phonebook = Object.assign(phonebook, {
           id: val.aid,
-          name: `${phonebook.firstName} ${phonebook.lastName}`,
+          name:
+            phonebook.displayName ||
+            `${phonebook.firstName} ${phonebook.lastName}`,
         })
         contactStore.upsertPhonebook(phonebook)
       })

--- a/src/pages/PagePhonebookUpdate.tsx
+++ b/src/pages/PagePhonebookUpdate.tsx
@@ -29,7 +29,8 @@ export class PagePhonebookUpdate extends Component<{
   save = (phonebook: Phonebook2) => {
     pbx.setContact(phonebook).then(this.onSaveSuccess).catch(this.onSaveFailure)
     Object.assign(phonebook, {
-      name: `${phonebook.firstName} ${phonebook.lastName}`,
+      name:
+        phonebook.displayName || `${phonebook.firstName} ${phonebook.lastName}`,
     })
     contactStore.upsertPhonebook(phonebook)
   }

--- a/src/pages/PagePhonebookUpdate.tsx
+++ b/src/pages/PagePhonebookUpdate.tsx
@@ -27,11 +27,12 @@ export class PagePhonebookUpdate extends Component<{
   }
 
   save = (phonebook: Phonebook2) => {
-    pbx.setContact(phonebook).then(this.onSaveSuccess).catch(this.onSaveFailure)
+    const displayName = `${phonebook.lastName} ${phonebook.firstName}`
     Object.assign(phonebook, {
-      name:
-        phonebook.displayName || `${phonebook.firstName} ${phonebook.lastName}`,
+      name: displayName,
+      displayName,
     })
+    pbx.setContact(phonebook).then(this.onSaveSuccess).catch(this.onSaveFailure)
     contactStore.upsertPhonebook(phonebook)
   }
   onSaveSuccess = () => {

--- a/src/stores/contactStore.ts
+++ b/src/stores/contactStore.ts
@@ -29,6 +29,7 @@ export type Phonebook2 = {
   book: string
   firstName: string
   lastName: string
+  displayName?: string
   workNumber: string
   cellNumber: string
   homeNumber: string


### PR DESCRIPTION
when making a call from the phonebook, the display names of the other party on the outgoing call screen and the call screen are in the order of "First name" and "Last Name".
The history is the same.
In Japan, the names are in the order of "Last name" and "First Name".
If the language is Japanese, reverse the order of names.