### PR TITLE
Fix issue: Ring ring can't not stop when run background and lock device

### DIFF
--- a/src/components/CallVoicesUI.tsx
+++ b/src/components/CallVoicesUI.tsx
@@ -7,18 +7,30 @@ import { BrekekeUtils } from '../utils/RnNativeModules'
 
 export class IncomingItem extends Component {
   ringtonePlaying = false
+  isUnmounted = false
   async componentDidMount() {
     if (Platform.OS === 'android' && (await BrekekeUtils.isSilent())) {
       return
     }
+    // Incase component unmount already
+    if (this.isUnmounted) {
+      return
+    }
+
     IncallManager.startRingtone('_BUNDLE_')
     this.ringtonePlaying = true
     // TODO stop ringtone if user press hardware button
     // https://www.npmjs.com/package/react-native-keyevent
   }
   componentWillUnmount() {
-    IncallManager.stopRingtone()
-    this.ringtonePlaying = false
+    // Incase component unmount before mounted(async)
+    if (!this.ringtonePlaying) {
+      this.isUnmounted = true
+    } else {
+      IncallManager.stopRingtone()
+      this.ringtonePlaying = false
+    }
+
     if (Platform.OS === 'android') {
       // Bug speaker auto turn on after call stopRingtone/stopRingback
       IncallManager.setForceSpeakerphoneOn(callStore.isLoudSpeakerEnabled)


### PR DESCRIPTION
Reproduce:
1. Start BrekekePhone from the absence of the BrekekePhone process and sign in.
2. Press the ○ button to put the Brekeke Phone in the background and then lock the device.
3. Make a call from 2004 to 2002 and receive a Brekeke Phone.
4. 2004 cancels the call.
5. In 2002, the incoming call screen disappears, the vibration stops and the idle state is set, but only the ringtone does not stop.