### PR TITLE
Fix issue: 529

### DIFF
--- a/src/pages/PageCallRecents.tsx
+++ b/src/pages/PageCallRecents.tsx
@@ -18,14 +18,14 @@ export class PageCallRecents extends Component {
   appStateSubscription?: NativeEventSubscription
   componentDidMount = () => {
     if (Platform.OS === 'ios') {
-      // for case the first go to this page
-      PushNotification.resetBadgeNumber()
-
-      this.appStateSubscription = AppState.addEventListener('change', () => {
+      const h = () => {
         if (AppState.currentState === 'active') {
           PushNotification.resetBadgeNumber()
         }
-      })
+      }
+      // Reset notification badge whenever go to this page
+      h()
+      this.appStateSubscription = AppState.addEventListener('change', h)
     }
   }
   componentWillUnmount = () => {

--- a/src/pages/PageCallRecents.tsx
+++ b/src/pages/PageCallRecents.tsx
@@ -18,6 +18,9 @@ export class PageCallRecents extends Component {
   appStateSubscription?: NativeEventSubscription
   componentDidMount = () => {
     if (Platform.OS === 'ios') {
+      // for case the first go to this page
+      PushNotification.resetBadgeNumber()
+
       this.appStateSubscription = AppState.addEventListener('change', () => {
         if (AppState.currentState === 'active') {
           PushNotification.resetBadgeNumber()


### PR DESCRIPTION
**Issue**:

> User has navigated to Call\Recents, after 5 seconds the the badge number is not cleared

**Reproduce**:

>Steps:

> 1. A: Brekeke app installed on iOS 15 device
> 2. B: Brekeke app installed on Android 11 device
> 3. A switches to background mode
> 4. B calls A, A does not answer
> 5. B ends the call after 10s
> 6. A goes to hom screen of phone
> 7. A taps on the brekeke app
> 8. A navigates to Call\Recents and waits about 10 seconds
> 
> Expected Result:
>       After step 8, the badge number must be cleared
> 
> Actual Result:
>       After the step 8, the badge number is still 1
