### PR TITLE
Issue 544 545

### DIFF
--- a/src/stores/AuthPBX.ts
+++ b/src/stores/AuthPBX.ts
@@ -41,7 +41,7 @@ class AuthPBX {
       }),
     )
   }
-  private authWithCheckDebounced = debounce(this.authWithCheck, 300)
+  private authWithCheckDebounced = debounce(this.authWithCheck, 30000)
 }
 
 export const authPBX = new AuthPBX()

--- a/src/stores/AuthSIP.ts
+++ b/src/stores/AuthSIP.ts
@@ -6,6 +6,7 @@ import { PbxGetProductInfoRes } from '../api/brekekejs'
 import { pbx } from '../api/pbx'
 import { sip } from '../api/sip'
 import { updatePhoneIndex } from '../api/updatePhoneIndex'
+import { BackgroundTimer } from '../utils/BackgroundTimer'
 import { SipPn } from '../utils/PushNotification-parse'
 import { getAuthStore } from './authStore'
 import { sipErrorEmitter } from './sipErrorEmitter'
@@ -116,6 +117,13 @@ class AuthSIP {
     if (!sipShouldAuth) {
       return
     }
+    if (s.sipTotalFailure > 1) {
+      BackgroundTimer.setTimeout(
+        this.authWithCheckDebounced,
+        s.sipTotalFailure < 5 ? s.sipTotalFailure * 1000 : 15000,
+      )
+      return
+    }
     this.authWithoutCatch().catch(
       action((err: Error) => {
         console.error('SIP PN debug: set sipState failure catch')
@@ -126,7 +134,7 @@ class AuthSIP {
       }),
     )
   }
-  private authWithCheckDebounced = debounce(this.authWithCheck, 30000)
+  private authWithCheckDebounced = debounce(this.authWithCheck, 300)
 }
 
 export const authSIP = new AuthSIP()

--- a/src/stores/AuthSIP.ts
+++ b/src/stores/AuthSIP.ts
@@ -126,7 +126,7 @@ class AuthSIP {
       }),
     )
   }
-  private authWithCheckDebounced = debounce(this.authWithCheck, 300)
+  private authWithCheckDebounced = debounce(this.authWithCheck, 30000)
 }
 
 export const authSIP = new AuthSIP()


### PR DESCRIPTION
**Issue 544:**

> Brekeke phone retries registration many time in short duration when it's IP is not allowed from PAL settings

**Reproduce**

> 1. Go to PAL setting on PBX and set pattern to restrict IP of brekeke phone, and just allow local IP, Ex: ^192\.168\.1\.+$.
> 2. Brekeke phone from extra network (like using 3G), and login 
> => It failed to login and the app retries reg manytime in short duration

**Issue 545**

> Brekeke phone retries registration many times when killed SIP Server

**Reproduce**

> 1. Kill SIP server process: check current process by lsof -i:5060.
> Then kill -9 <process id>
> 2. Brekeke phone from extra network (like using 3G), and login 
> => It failed to login and the app retries reg manytimes

**Change auto check Author from 300ms -> 30000ms **

