### PR TITLE
Fix issue 456 and 533

### DIFF
--- a/src/utils/callkeep.ts
+++ b/src/utils/callkeep.ts
@@ -188,7 +188,7 @@ export const setupCallKeep = async () => {
     // Only in ios
     console.error('CallKeep debug: didDeactivateAudioSession')
     callStore.calls
-      .filter(c => c.answered && !c.holding)
+      .filter(c => c.answered && !c.holding && c.id !== callStore.currentCallId)
       .forEach(c => c.toggleHoldWithCheck())
   }
 


### PR DESCRIPTION
**Issue 456**

> The second incomming call is put on hold after tapping the button "Hold&Accept"

**Reproduce**

> Steps:
> 1. User 101 (iOS) and User 102 are talking on brekeke app
> 2. User 103 calls to User 101
> 3. User 101 taps on the button Hold&Accept
> 
> Expected Result:
>      - The call from 102 is put on hold
>      - The call from 103 is connected and able to talk
> 
> Actual Result:
>       - The call from 102 and 103 are both putted on hold, 

**Issue 533**

> While talking, if selecting an "End/accept" option for an incoming call, the new call is connected but it shows a Hold button as toggle on.

**Reproduce**

> Steps:
> 1. User 101 (iOS) and User 102 are talking on brekeke app
> 2. User 103 calls to User 101
> 3. User 101 taps on the button End&Accept
> 
> Expected Result:
>      - The call from 102 is disconnected 
>      - The call from 103 is connected and able to talk
> 
> Actual Result:
>       - The call from 102 is disconnected  and 103  putted on hold, 