### PR TITLE
#544, #545: Fix retry many time login pbx/sip

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -48,6 +48,7 @@ class Api {
     console.error('PBX PN debug: set pbxState success')
     const s = getAuthStore()
     s.pbxState = 'success'
+    s.pbxTotalFailure = 0
     await waitSip()
     await pbx.getConfig()
     const cp = s.currentProfile
@@ -105,6 +106,7 @@ class Api {
     const s = getAuthStore()
     s.sipPn.sipAuth = ''
     s.sipState = 'success'
+    s.sipTotalFailure = 0
     authPBX.auth()
   }
   onSIPConnectionStopped = (e: { reason: string; response: string }) => {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -74,6 +74,7 @@ class Api {
   }
   onPBXConnectionStopped = () => {
     getAuthStore().pbxState = 'stopped'
+    getAuthStore().pbxTotalFailure += 1
   }
   onPBXConnectionTimeout = () => {
     getAuthStore().pbxState = 'failure'
@@ -111,6 +112,7 @@ class Api {
     if (!e?.reason && !e?.response) {
       console.error('SIP PN debug: set sipState stopped')
       getAuthStore().sipState = 'stopped'
+      s.sipTotalFailure += 1
     } else {
       console.error('SIP PN debug: set sipState failure stopped')
       s.sipState = 'failure'

--- a/src/stores/AuthPBX.ts
+++ b/src/stores/AuthPBX.ts
@@ -26,13 +26,15 @@ class AuthPBX {
     s.pbxState = 'stopped'
   }
 
+  private waitingTimeout = false
   @action private authWithCheck = async () => {
     const s = getAuthStore()
-    if (!s.pbxShouldAuth() || !s.currentProfile) {
+    if (!s.pbxShouldAuth() || !s.currentProfile || this.waitingTimeout) {
       return
     }
     if (s.pbxTotalFailure > 1) {
       const timeWait = s.pbxTotalFailure < 5 ? s.pbxTotalFailure * 1000 : 15000
+      this.waitingTimeout = true
       await waitTimeout(timeWait)
     }
     console.error('PBX PN debug: disconnect by AuthPBX.authWithCheck')
@@ -45,6 +47,7 @@ class AuthPBX {
         console.error('Failed to connect to pbx', err)
       }),
     )
+    this.waitingTimeout = false
   }
   private authWithCheckDebounced = debounce(this.authWithCheck, 300)
 }

--- a/src/stores/AuthSIP.ts
+++ b/src/stores/AuthSIP.ts
@@ -6,8 +6,8 @@ import { PbxGetProductInfoRes } from '../api/brekekejs'
 import { pbx } from '../api/pbx'
 import { sip } from '../api/sip'
 import { updatePhoneIndex } from '../api/updatePhoneIndex'
-import { BackgroundTimer } from '../utils/BackgroundTimer'
 import { SipPn } from '../utils/PushNotification-parse'
+import { waitTimeout } from '../utils/waitTimeout'
 import { getAuthStore } from './authStore'
 import { sipErrorEmitter } from './sipErrorEmitter'
 
@@ -102,7 +102,7 @@ class AuthSIP {
     pn.sipAuth = await pbx.createSIPAccessToken(pn.phoneId)
     await this.authPnWithoutCatch(pn)
   }
-  authWithCheck = () => {
+  authWithCheck = async () => {
     const s = getAuthStore()
     const sipShouldAuth = s.sipShouldAuth()
     console.error(
@@ -118,11 +118,8 @@ class AuthSIP {
       return
     }
     if (s.sipTotalFailure > 1) {
-      BackgroundTimer.setTimeout(
-        this.authWithCheckDebounced,
-        s.sipTotalFailure < 5 ? s.sipTotalFailure * 1000 : 15000,
-      )
-      return
+      const timeWait = s.sipTotalFailure < 5 ? s.sipTotalFailure * 1000 : 15000
+      await waitTimeout(timeWait)
     }
     this.authWithoutCatch().catch(
       action((err: Error) => {

--- a/src/stores/AuthUC.ts
+++ b/src/stores/AuthUC.ts
@@ -56,6 +56,7 @@ class AuthUC {
     this.loadUnreadChats().then(
       action(() => {
         s.ucState = 'success'
+        s.ucTotalFailure = 0
       }),
     )
   }


### PR DESCRIPTION
**Issue 544:**

> Brekeke phone retries registration many time in short duration when it's IP is not allowed from PAL settings

**Reproduce**

> 1. Go to PAL setting on PBX and set pattern to restrict IP of brekeke phone, and just allow local IP, Ex: ^192\.168\.1\.+$.
> 2. Brekeke phone from extra network (like using 3G), and login 
> => It failed to login and the app retries reg manytime in short duration

**Issue 545**

> Brekeke phone retries registration many times when killed SIP Server

**Reproduce**

> 1. Kill SIP server process: check current process by lsof -i:5060.
> Then kill -9 <process id>
> 2. Brekeke phone from extra network (like using 3G), and login 
> => It failed to login and the app retries reg manytimes

**Change auto check Author from 300ms -> 30000ms **