### PR TITLE
#532: Fix don't display group name

### DIFF
--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -288,7 +288,7 @@ class UserStore {
       const selectedItemCount = this.isSelectedAddAllUser
         ? renderData.length
         : renderData.filter(i => this.selectedUserIds[i.user_id]).length
-      return `${selectedItemCount}/${renderData.length}`
+      return `${sectionTitle} ${selectedItemCount}/${renderData.length}`
     }
 
     const indexGroup = this.dataGroupAllUser.findIndex(


### PR DESCRIPTION
Steps:
   1. User launch Brekeke app and sign in with username and password
   2. Navigate to Contact\Buddy
   3. Click on the button Edit buddy list
   4. Check on the Edit grouping and user order

Expected result
   At the step 3): all group names display on the screen
    At the step 4): all group names display on the screen

Actual Result:
   At the step 3), No any grooup name displays on the screen.