### PR TITLE
#547, #548: fix display name of chat and fix issue sound of chat notification 

### DIFF
--- a/src/pages/PageChatDetail.tsx
+++ b/src/pages/PageChatDetail.tsx
@@ -133,7 +133,7 @@ export class PageChatDetail extends Component<{
         containerRef={this.setViewRef}
         fabRender={this.renderChatInput}
         onBack={Nav().backToPageChatRecents}
-        title={getPartyName(id)}
+        title={getPartyName(id) || id} // for user not set username
         isShowToastMessage={isShowToastMessage}
         incomingMessage={incomingMessage}
       >

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -200,7 +200,8 @@ class ChatStore {
     if (isGroup) {
       name = chatStore.getGroupById(threadId)?.name
     } else {
-      name = getPartyName(threadId) || ''
+      // user not set username
+      name = getPartyName(threadId) || threadId
     }
     if (m.length === 1 && AppState.currentState !== 'active') {
       this.pushChatNotification(name, m[0]?.text || '', threadId)

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -218,6 +218,7 @@ class ChatStore {
     }
     const shouldPlayChatNotificationSoundVibration =
       !isTalking &&
+      AppState.currentState === 'active' &&
       (isGroup
         ? !(s?.name === 'PageChatGroupDetail' && s?.groupId === threadId)
         : !(s?.name === 'PageChatDetail' && s?.buddy === threadId))


### PR DESCRIPTION
**#547:**
When a chat is received from a user who does not have a display name set, the notification title will be BrekekePhoneDev.
In 2.9.8, the phone number was displayed, so it is a degradation.
This happens on both iOS and android.
[procedure]
1. Log in with UC enabled.
2. Press the circle button to bring the Brekeke Phone to the background.
3. Send a chat from another device to Brekeke Phone.

**#548**
The notification sound when receiving a UC chat is strange.
When receiving the first chat, both the original sound and the notification sound set on the terminal will sound.
When receiving the second chat, the original sound does not sound, but the notification sound set on the terminal sounds.
This happens on android. 
[procedure]
1. Log in with UC enabled.
2. Press the circle button to bring the Brekeke Phone to the background.
3. Send a chat from another device to Brekeke Phone.
4. Send a chat from another device to Brekeke Phone again