### PR TITLE
update fix notification misscall don't display if user don't exist on local

### DIFF
--- a/src/api/sip.ts
+++ b/src/api/sip.ts
@@ -35,7 +35,7 @@ export const checkAndRemovePnTokenViaSip = async (
     return
   }
   alreadyRemovePnTokenViaSip[k] = true
-  console.log('removePnTokenViaSip debug: begin')
+  console.log('checkAndRemovePnTokenViaSip debug: begin')
   const phone = getWebrtcClient(toBoolean(n.sipPn.dtmfSendPal))
   phone.startWebRTC({
     // register: false,
@@ -56,13 +56,13 @@ export const checkAndRemovePnTokenViaSip = async (
   const o = phone._ua?.registrator?.()!
   if (!started || !o) {
     console.log(
-      `removePnTokenViaSip debug: started=${started} registrator=${!!o}`,
+      `checkAndRemovePnTokenViaSip debug: started=${started} registrator=${!!o}`,
     )
   }
   o._registered = true
   o.setExtraHeaders(['X-PN-Manage: remove'])
   phone.stopWebRTC()
-  console.log('removePnTokenViaSip debug: done')
+  console.log('checkAndRemovePnTokenViaSip debug: done')
 }
 
 export class SIP extends EventEmitter {

--- a/src/utils/PushNotification-parse.ts
+++ b/src/utils/PushNotification-parse.ts
@@ -3,6 +3,7 @@ import get from 'lodash/get'
 import { AppState, Platform } from 'react-native'
 
 import { checkAndRemovePnTokenViaSip } from '../api/sip'
+import { accountStore } from '../stores/accountStore'
 import { getAuthStore } from '../stores/authStore'
 import { callStore } from '../stores/callStore'
 import { Nav } from '../stores/Nav'
@@ -197,6 +198,12 @@ export const parse = async (raw: { [k: string]: unknown }, isLocal = false) => {
   }
 
   checkAndRemovePnTokenViaSip(n, callStore)
+
+  await accountStore.waitStorageLoaded()
+  if (!getAuthStore().findAccountByPn(n)) {
+    console.error('removePnTokenViaSip PN exist account')
+    return
+  }
 
   isLocal = Boolean(
     isLocal ||

--- a/src/utils/PushNotification-parse.ts
+++ b/src/utils/PushNotification-parse.ts
@@ -201,7 +201,7 @@ export const parse = async (raw: { [k: string]: unknown }, isLocal = false) => {
 
   await accountStore.waitStorageLoaded()
   if (!getAuthStore().findAccountByPn(n)) {
-    console.error('removePnTokenViaSip PN exist account')
+    console.log('checkAndRemovePnTokenViaSip debug: account not exist')
     return
   }
 


### PR DESCRIPTION
update fix notification misscall don't display if user don't exist on local

**Reproduce**:
- login a acount to brekeke app 
- make sure will get PN incoming call 
- logout 
- disable internet 
- remove account and kill app 
- make a call to account have been remove 

**Observation**:
The device will get missed call notification

