### PR TITLE
Fix issue no voice on ios

### DIFF
--- a/src/components/CallVoicesUI.tsx
+++ b/src/components/CallVoicesUI.tsx
@@ -1,10 +1,20 @@
 import { Component } from 'react'
-import { Platform } from 'react-native'
+import { Platform, StyleSheet } from 'react-native'
 import IncallManager from 'react-native-incall-manager'
+import Video from 'react-native-video'
 
 import { callStore } from '../stores/callStore'
 import { BrekekeUtils } from '../utils/RnNativeModules'
 
+const css = StyleSheet.create({
+  video: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+  },
+})
 export class IncomingItem extends Component {
   ringtonePlaying = false
   async componentDidMount() {
@@ -30,18 +40,15 @@ export class IncomingItem extends Component {
 }
 
 export class OutgoingItem extends Component {
-  componentDidMount() {
-    IncallManager.startRingback('_BUNDLE_')
-  }
-  componentWillUnmount() {
-    IncallManager.stopRingback()
-    if (Platform.OS === 'android') {
-      // Bug speaker auto turn on after call stopRingtone/stopRingback
-      IncallManager.setForceSpeakerphoneOn(callStore.isLoudSpeakerEnabled)
-    }
-  }
   render() {
-    return null
+    return (
+      <Video
+        source={require('../assets/incallmanager_ringback.mp3')}
+        style={css.video}
+        repeat={true}
+        playInBackground={true}
+      />
+    )
   }
 }
 export class OutgoingItemWithSDP extends Component<{


### PR DESCRIPTION
## [iOS] [Major]: In case using early media, Call has no voice if making call from iOS device
Steps:
(1) Using apps server, and go to ARS route "image_test_tuc" and change "SPD 18x" field in Pattern IN to "append"
(2) Login user 201 (pass:123; tenant: tuc) on iOS device and call to other user 202 (pass:123; tenant: tuc)
=> While Callee (202) ringing, "Control & Keypad" shows on caller (201)
(3) 202 pickups.
=> The call is connected, but have no voice

## [iOS] [Major] It does not play early media at caller.
Steps:
(1) Login user 201 (pass:123; tenant: tuc) on iOS device and call to an IVR ext (14010)
** 14010 - this number tires to a flow designer app (early_mdia) in "tuc" tenant. This app will play prompts before answer.
=> The call is connected to an IVR app. But it does not hear early media.
*** It does not occur with Android.