### PR TITLE
update UI fix issue text change

### DIFF
--- a/android/app/src/main/res/layout/incoming_call_activity.xml
+++ b/android/app/src/main/res/layout/incoming_call_activity.xml
@@ -251,7 +251,7 @@
       <RelativeLayout
         android:id="@+id/view_button_end"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_height="70dp"
         android:layout_marginBottom="20dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
@@ -300,9 +300,10 @@
           <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="5dp"
+            android:layout_marginTop="5dp"
             android:gravity="center"
             android:orientation="vertical"
+            android:minWidth="90dp"
           >
             <Button
               android:id="@+id/btn_transfer"
@@ -329,9 +330,10 @@
           <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="5dp"
+            android:layout_marginTop="5dp"
             android:gravity="center"
             android:orientation="vertical"
+            android:minWidth="90dp"
           >
             <Button
               android:id="@+id/btn_park"
@@ -358,9 +360,10 @@
           <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="5dp"
+            android:layout_marginTop="5dp"
             android:gravity="center"
             android:orientation="vertical"
+            android:minWidth="90dp"
           >
             <Button
               android:id="@+id/btn_video"
@@ -384,9 +387,10 @@
           <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="5dp"
+            android:layout_marginTop="5dp"
             android:gravity="center"
             android:orientation="vertical"
+            android:minWidth="90dp"
           >
             <Button
               android:id="@+id/btn_speaker"
@@ -411,14 +415,16 @@
         <LinearLayout
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
+          android:layout_marginTop="5dp"
           android:layout_gravity="center"
         >
           <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="5dp"
             android:gravity="center"
             android:orientation="vertical"
+            android:minWidth="90dp"
+            android:layout_marginTop="5dp"
           >
             <Button
               android:id="@+id/btn_mute"
@@ -436,15 +442,17 @@
               android:textColor="@color/white"
               android:textSize="14dp"
               android:textStyle="bold"
+              android:textAlignment="center"
             />
           </LinearLayout>
 
           <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="5dp"
             android:gravity="center"
             android:orientation="vertical"
+            android:minWidth="90dp"
+            android:layout_marginTop="5dp"
           >
             <Button
               android:id="@+id/btn_record"
@@ -468,9 +476,10 @@
           <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="5dp"
             android:gravity="center"
             android:orientation="vertical"
+            android:minWidth="90dp"
+            android:layout_marginTop="5dp"
           >
             <Button
               android:id="@+id/btn_dtmf"
@@ -497,9 +506,10 @@
           <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="5dp"
             android:gravity="center"
             android:orientation="vertical"
+            android:minWidth="90dp"
+            android:layout_marginTop="5dp"
           >
             <Button
               android:id="@+id/btn_hold"

--- a/src/components/ButtonIcon.tsx
+++ b/src/components/ButtonIcon.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { StyleSheet, TouchableOpacityProps, View } from 'react-native'
+import { Platform, StyleSheet, TouchableOpacityProps, View } from 'react-native'
 import Svg, { Path } from 'react-native-svg'
 
 import { RnText, RnTouchableOpacity } from './Rn'
@@ -16,7 +16,8 @@ const css = StyleSheet.create({
   },
   ButtonIcon_Name: {
     paddingTop: 5,
-    maxWidth: 74,
+    minWidth: Platform.OS === 'ios' ? 70 : 80,
+    textAlign: 'center',
   },
 })
 


### PR DESCRIPTION
[case 2]
If you press the mute button on the call screen to mute it, the icon will slide a little.
If you press the mute button again to cancel the mute state, the icon will return to the original display.
This occurs on both the locked and unlocked call screens.
This only occurs on android.

[procedure]
1. Make a call to Brekeke Phone.
2. Brekeke Phone answers the incoming call.
3. Press the mute icon on the Brekeke Phone.

[case 3]
If you press the hold button on the call screen to put it on hold, the avatar display will be slightly larger.
If you press the hold button again to release the hold state, the size of the avatar will return to its original size.
This occurs on the locked call screen.
This only occurs on android.

[procedure]
1. Lock the Brekeke Phone device.
2. Make a call to Brekeke Phone.
3. Brekeke Phone answers the incoming call.
4. Press the hold icon on the Brekeke Phone.