### PR TITLE
Fix issue speaker android and Proximity IOS

### DIFF
--- a/src/components/CallVoicesUI.tsx
+++ b/src/components/CallVoicesUI.tsx
@@ -51,7 +51,6 @@ export class OutgoingItem extends Component<{}, { isPause: boolean }> {
   componentWillUnmount() {
     if (Platform.OS === 'android') {
       IncallManager.stop()
-      IncallManager.setForceSpeakerphoneOn(callStore.isLoudSpeakerEnabled)
     }
   }
   render() {
@@ -73,11 +72,17 @@ export class AnsweredItem extends Component<{
   voiceStreamObject: MediaStream | null
 }> {
   componentDidMount = () => {
+    // update status speaker, again
+    // ref: https://stackoverflow.com/questions/41762392/what-happens-with-onaudiofocuschange-when-a-phone-call-ends
+    if (Platform.OS === 'android') {
+      IncallManager.start()
+      setTimeout(() => {
+        IncallManager.setForceSpeakerphoneOn(callStore.isLoudSpeakerEnabled)
+      }, 2000)
+    }
+
     const currentCall = callStore.getCurrentCall()
     currentCall && sip.enableMedia(currentCall.id)
-    // update status speaker, again
-    IncallManager.start()
-    IncallManager.setForceSpeakerphoneOn(callStore.isLoudSpeakerEnabled)
   }
   render() {
     return null


### PR DESCRIPTION
**issue:**
Android make a call, during ringing period press on speaker button -> SPEAKER ON mode is working.
Callee answer the call and talking -> SPEAKER button is still ON in Android caller but the SPEAKER mode is OFF.

**issue:**
(1) Make a call with Brekeke phone (iOS)
(2) Brekeke phone pick up the call
=> Proximity works on the phone device (iOS)
(3) After talking for a while, disconnecting the call.
=> The call has disconnected. But the proximity sensor still work. 
Even kill the phone the proximity still works.
*** The proximity just stops when making a new call to brekeke phone
