### PR TITLE
Fix issue: RBT low volume after make first call

### DIFF
--- a/src/components/CallVoicesUI.tsx
+++ b/src/components/CallVoicesUI.tsx
@@ -97,7 +97,7 @@ export const VideoRBT = (p: { isPaused: boolean }) => {
       style={css.video}
       paused={p.isPaused}
       repeat={true}
-      // ignoreSilentSwitch={'obey'}
+      ignoreSilentSwitch={'ignore'}
       playInBackground={true}
       audioOnly
     />


### PR DESCRIPTION
Issue:
1. Exit the Brekeke Phone app process.
2. Sign in with your Brekeke Phone.
3. Make a call from Brekeke Phone.
4. The other party answers and the call is in progress.
5. End the call.
6. Make a call from Brekeke Phone again.

Resolved:
Using option for play RBT:  [ignoreSilentSwitch](https://github.com/react-native-video/react-native-video/blob/master/API.md#ignoresilentswitch)
"inherit" (default) - Use the default AVPlayer behavior => after answer call, AVPlayer maybe change => volume of RBT change according to. So, we use `ignoreSilentSwitch={'ignore'}` to skip that change 
 
