### PR TITLE
Improve phonebook

### DIFF
--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -325,15 +325,15 @@ export class PBX extends EventEmitter {
     if (!this.client) {
       return
     }
-
     const res = await this.client.call_pal('getContactList', {
       phonebook: '',
       search_text,
-      shared,
+      // The shared is just indicate if the phonebook is shared or not.
+      // In the future, maybe you can add a filter like PBX UI.
+      //shared,
       offset,
       limit,
     })
-
     return res.map(contact => ({
       id: contact.aid,
       display_name: contact.display_name,

--- a/src/components/ContactUserItem.tsx
+++ b/src/components/ContactUserItem.tsx
@@ -118,6 +118,7 @@ export const UserItem: FC<
     isSelection?: boolean
     isSelected?: boolean
     parkNumber?: string
+    phonebook?: string
     onSelect?: () => void
   }>
 > = observer(p0 => {
@@ -146,6 +147,7 @@ export const UserItem: FC<
     isSelection,
     isSelected,
     parkNumber,
+    phonebook,
     onSelect,
     ...p
   } = p0
@@ -236,6 +238,12 @@ export const UserItem: FC<
           {!!parkNumber && (
             <RnText normal small style={css.CallCreatedAt}>
               {intl`Park number: ` + `${parkNumber}`}
+            </RnText>
+          )}
+
+          {!!phonebook && (
+            <RnText normal small style={css.CallCreatedAt}>
+              {phonebook}
             </RnText>
           )}
           {!isRecentCall && !!lastMessage && (

--- a/src/pages/PageContactPhonebook.tsx
+++ b/src/pages/PageContactPhonebook.tsx
@@ -17,8 +17,6 @@ import { UserItem } from '../components/ContactUserItem'
 import { Field } from '../components/Field'
 import { Layout } from '../components/Layout'
 import { RnText, RnTouchableOpacity } from '../components/Rn'
-import { accountStore } from '../stores/accountStore'
-import { getAuthStore } from '../stores/authStore'
 import { callStore } from '../stores/callStore'
 import { contactStore, Phonebook2 } from '../stores/contactStore'
 import { intl, intlDebug } from '../stores/intl'
@@ -45,7 +43,12 @@ export class PageContactPhonebook extends Component {
       BackgroundTimer.clearInterval(id)
     }, 1000)
   }
-
+  componentWillUnmount() {
+    if (contactStore.isDeleteState) {
+      contactStore.isDeleteState = false
+      contactStore.selectedContactIds = {}
+    }
+  }
   update = (id: string) => {
     const contact = contactStore.getPhonebookById(id)
     if (contact?.loaded) {
@@ -239,6 +242,7 @@ export class PageContactPhonebook extends Component {
         onPress: contactStore.loadContacts,
       },
     ]
+
     return (
       <Layout
         description={intl`Your phonebook contacts`}
@@ -253,7 +257,8 @@ export class PageContactPhonebook extends Component {
           onValueChange={this.updateSearchText}
           value={contactStore.phonebookSearchTerm}
         />
-        <Field
+        {/* Next time, will make filter like PBX UI. */}
+        {/* <Field
           label={intl`SHOW SHARED CONTACTS`}
           onValueChange={(v: boolean) => {
             if (pbx.client && getAuthStore().pbxState === 'success') {
@@ -267,7 +272,7 @@ export class PageContactPhonebook extends Component {
           }}
           type='Switch'
           value={getAuthStore().getCurrentAccount()?.displaySharedContacts}
-        />
+        /> */}
         <View>
           {groups.map(gr => (
             <Fragment key={gr.key}>

--- a/src/pages/PageContactPhonebook.tsx
+++ b/src/pages/PageContactPhonebook.tsx
@@ -297,7 +297,8 @@ export class PageContactPhonebook extends Component {
                     iconFuncs={[() => this.onIcon0(u), () => this.update(u.id)]}
                     icons={[mdiPhone, mdiInformation]}
                     key={i}
-                    name={u?.display_name || intl`<Unnamed>`}
+                    phonebook={`${u.phonebook}${u.shared ? 'Ⓢ' : ''}`}
+                    name={`${u?.display_name || intl`<Unnamed>`}`}
                   />
                 ),
               )}


### PR DESCRIPTION
- Remove toggle show shared contact from the UI so you can always show all the contacts. Next time, will make UI like phonebook Pbx UI
- When I select a "Delete Contacts" option in Phonebook screen, it changes to screen that can select to delete contacts. And that screen still keeps if I move to other tabs.
It would better reset the Phonebook screen after leaving it.
- Show the phonebook name under the display name on Phonebook Items of list phonebook.
- Add Ⓢ after the phonebook name if it is shared