### PR TITLE
Fix issue speaker RBT on ios

### DIFF
--- a/src/components/CallVoices.tsx
+++ b/src/components/CallVoices.tsx
@@ -24,6 +24,7 @@ export const CallVoices = observer(() => {
   const outgoingWithSDP = currentCall && currentCall?.withSDP
 
   const isPaused = !(isOutgoingCallStart && !outgoingWithSDP)
+
   return (
     <>
       {isOutgoingCallStart &&
@@ -34,7 +35,7 @@ export const CallVoices = observer(() => {
         ))}
       {
         // load RBT first
-        Platform.OS === 'ios' && (
+        Platform.OS === 'ios' && isOutgoingCallStart && (
           <VideoRBT
             isPaused={isPaused}
             isLoudSpeaker={callStore.isLoudSpeakerEnabled}


### PR DESCRIPTION
**Issue**:
 The ringback tone still plays after cancelled a call and switching a Brekeke phone to background.
(1) Login Brekeke phone and make an outgoing call
(2) While a callee is ringing, the caller (Brekeke phone) turns on speaker then cancels the call.
(3) After the call is disconnected, switching the Brekeke phone to Background then open it again.
Issue: It plays ringing back tone, and it will never stop until killing the Brekeke phone