### PR TITLE
Hide button call follow pbxConfig get from getProductInfo

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
@@ -35,6 +35,30 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class BrekekeUtils extends ReactContextBaseJavaModule {
+
+  public class Config {
+    public  boolean hideBtnTransfer;
+    public   boolean hideBtnPark;
+    public  boolean hideBtnVideo;
+    public   boolean hideBtnSpeaker;
+    public  boolean hideBtnMute;
+    public   boolean hideBtnRecord;
+    public  boolean hideBtnDTMF;
+    public   boolean hideBtnHold;
+
+    public Config() {
+      this.hideBtnTransfer = false;
+      this.hideBtnPark = false;
+      this.hideBtnVideo = false;
+      this.hideBtnSpeaker = false;
+      this.hideBtnMute = false;
+      this.hideBtnRecord = false;
+      this.hideBtnDTMF = false;
+      this.hideBtnHold = false;
+    }
+
+  }
+
   public static RCTDeviceEventEmitter eventEmitter;
 
   public static void emit(String name, String data) {
@@ -69,11 +93,13 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
   public static boolean isAppActive = false;
   public static boolean isAppActiveLocked = false;
   public static boolean firstShowCallAppActive = false;
+  public static Config config;
 
   BrekekeUtils(ReactApplicationContext c) {
     super(c);
     ctx = c;
     initStaticServices(c);
+    config = new Config();
   }
 
   @Override
@@ -522,6 +548,18 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
   //
   // React methods
   //
+  @ReactMethod
+  public void setConfig(Boolean hideBtnTransfer, Boolean hideBtnPark,Boolean hideBtnVideo,Boolean hideBtnSpeaker,
+   Boolean hideBtnMute,Boolean hideBtnRecord,Boolean hideBtnDTMF, Boolean hideBtnHold) {
+    this.config.hideBtnTransfer = hideBtnTransfer;
+    this.config.hideBtnPark = hideBtnPark;
+    this.config.hideBtnVideo = hideBtnVideo;
+    this.config.hideBtnSpeaker = hideBtnSpeaker;
+    this.config.hideBtnMute = hideBtnMute;
+    this.config.hideBtnRecord = hideBtnRecord;
+    this.config.hideBtnDTMF = hideBtnDTMF;
+    this.config.hideBtnHold = hideBtnHold;
+  }
 
   @ReactMethod
   public void getInitialNotifications(Promise promise) {

--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -34,7 +34,7 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
       vCallManageLoading,
       vHeaderIncomingCall,
       vHeaderManageCall;
-  public LinearLayout vCallManageControls;
+  public LinearLayout vCallManageControls, vBtnTransfer, vBtnPark, vBtnVideo, vBtnSpeaker, vBtnMute, vBtnRecord, vBtnDTMF, vBtnHold;
   public View vCardAvatar;
   public View vCardAvatarTalking;
   public WebRTCView vWebrtcVideo;
@@ -133,6 +133,18 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
     videoLoading = (ProgressBar) findViewById(R.id.video_loading);
     vCallManage.setOnClickListener(this);
 
+//    view btn
+    vBtnTransfer = (LinearLayout) findViewById(R.id.ln_btn_transfer);
+    vBtnPark = (LinearLayout) findViewById(R.id.ln_btn_park);
+    vBtnVideo = (LinearLayout) findViewById(R.id.ln_btn_video);
+    vBtnSpeaker =(LinearLayout) findViewById(R.id.ln_btn_speaker);
+    vBtnMute = (LinearLayout) findViewById(R.id.ln_btn_mute);
+    vBtnRecord =  (LinearLayout) findViewById(R.id.ln_btn_record);
+    vBtnDTMF = (LinearLayout) findViewById(R.id.ln_btn_dtmf);
+    vBtnHold = (LinearLayout) findViewById(R.id.ln_btn_hold);
+    updateConfig();
+
+
     imgAvatar = (ImageView) findViewById(R.id.avatar);
     imgAvatarTalking = (ImageView) findViewById(R.id.avatar_talking);
     btnAnswer = (Button) findViewById(R.id.btn_answer);
@@ -185,7 +197,32 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
     updateLabels();
     updateHeader();
   }
-
+  public void  updateConfig(){
+    if(BrekekeUtils.config.hideBtnTransfer){
+      vBtnTransfer.setVisibility(View.GONE);
+    }
+    if(BrekekeUtils.config.hideBtnPark){
+      vBtnPark.setVisibility(View.GONE);
+    }
+    if(BrekekeUtils.config.hideBtnVideo){
+      vBtnVideo.setVisibility(View.GONE);
+    }
+    if(BrekekeUtils.config.hideBtnSpeaker){
+      vBtnSpeaker.setVisibility(View.GONE);
+    }
+    if(BrekekeUtils.config.hideBtnMute){
+      vBtnMute.setVisibility(View.GONE);
+    }
+    if(BrekekeUtils.config.hideBtnRecord){
+      vBtnRecord.setVisibility(View.GONE);
+    }
+    if(BrekekeUtils.config.hideBtnDTMF){
+      vBtnDTMF.setVisibility(View.GONE);
+    }
+    if(BrekekeUtils.config.hideBtnHold){
+      vBtnHold.setVisibility(View.GONE);
+    }
+  }
   public void updateHeader() {
     if ("large".equalsIgnoreCase(avatarSize)) {
       DisplayMetrics displayMetrics = new DisplayMetrics();

--- a/android/app/src/main/res/layout/incoming_call_activity.xml
+++ b/android/app/src/main/res/layout/incoming_call_activity.xml
@@ -257,12 +257,14 @@
           android:layout_gravity="center"
         >
           <LinearLayout
+            android:id="@+id/ln_btn_transfer"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
             android:gravity="center"
             android:minWidth="90dp"
             android:orientation="vertical"
+            android:visibility="visible"
           >
             <Button
               android:id="@+id/btn_transfer"
@@ -285,14 +287,16 @@
               android:textSize="14dp"
             />
           </LinearLayout>
-
+<!--btn park-->
           <LinearLayout
+            android:id="@+id/ln_btn_park"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
             android:gravity="center"
             android:minWidth="90dp"
             android:orientation="vertical"
+            android:visibility="visible"
           >
             <Button
               android:id="@+id/btn_park"
@@ -315,14 +319,16 @@
               android:textSize="14dp"
             />
           </LinearLayout>
-
+<!--btn video-->
           <LinearLayout
+            android:id="@+id/ln_btn_video"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
             android:gravity="center"
             android:minWidth="90dp"
             android:orientation="vertical"
+            android:visibility="visible"
           >
             <Button
               android:id="@+id/btn_video"
@@ -342,14 +348,16 @@
               android:textSize="14dp"
             />
           </LinearLayout>
-
+<!--btn speaker-->
           <LinearLayout
+            android:id="@+id/ln_btn_speaker"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
             android:gravity="center"
             android:minWidth="90dp"
             android:orientation="vertical"
+            android:visibility="visible"
           >
             <Button
               android:id="@+id/btn_speaker"
@@ -377,13 +385,16 @@
           android:layout_marginTop="5dp"
           android:layout_gravity="center"
         >
+<!--          btn mute-->
           <LinearLayout
+            android:id="@+id/ln_btn_mute"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
             android:gravity="center"
             android:minWidth="90dp"
             android:orientation="vertical"
+            android:visibility="visible"
           >
             <Button
               android:id="@+id/btn_mute"
@@ -404,14 +415,16 @@
               android:textSize="14dp"
             />
           </LinearLayout>
-
+<!--btn record-->
           <LinearLayout
+            android:id="@+id/ln_btn_record"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
             android:gravity="center"
             android:minWidth="90dp"
             android:orientation="vertical"
+            android:visibility="visible"
           >
             <Button
               android:id="@+id/btn_record"
@@ -431,14 +444,16 @@
               android:textSize="14dp"
             />
           </LinearLayout>
-
+<!--btn dtmf-->
           <LinearLayout
+            android:id="@+id/ln_btn_dtmf"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
             android:gravity="center"
             android:minWidth="90dp"
             android:orientation="vertical"
+            android:visibility="visible"
           >
             <Button
               android:id="@+id/btn_dtmf"
@@ -461,14 +476,16 @@
               android:textSize="14dp"
             />
           </LinearLayout>
-
+<!--btn hold-->
           <LinearLayout
+            android:id="@+id/ln_btn_hold"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
             android:gravity="center"
             android:minWidth="90dp"
             android:orientation="vertical"
+            android:visibility="visible"
           >
             <Button
               android:id="@+id/btn_hold"
@@ -488,6 +505,15 @@
               android:textSize="14dp"
             />
           </LinearLayout>
+        </LinearLayout>
+        <LinearLayout
+          android:id="@+id/ln_flex1"
+          android:layout_width="wrap_content"
+          android:layout_height="100dp"
+          android:orientation="horizontal"
+          android:visibility="gone"
+        >
+
         </LinearLayout>
       </LinearLayout>
 

--- a/src/api/brekekejs.d.ts
+++ b/src/api/brekekejs.d.ts
@@ -162,6 +162,14 @@ export type PbxGetProductInfoRes = {
   'webphone.allusers': string
   'webphone.users.max': string
   'webphone.pal.param.user': string
+  'webphone.call.transfer': string
+  'webphone.call.speaker': string
+  'webphone.call.park': string
+  'webphone.call.video': string
+  'webphone.call.mute': string
+  'webphone.call.record': string
+  'webphone.call.dtmf': string
+  'webphone.call.hold': string
 }
 export type PbxGetProductInfoParam = {
   webphone: string

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -2,12 +2,14 @@ import 'brekekejs/lib/jsonrpc'
 import 'brekekejs/lib/pal'
 
 import EventEmitter from 'eventemitter3'
+import { Platform } from 'react-native'
 
 import { embedApi } from '../embed/embedApi'
 import { Account, accountStore } from '../stores/accountStore'
 import { getAuthStore, waitPbx } from '../stores/authStore'
 import { PbxUser, Phonebook2 } from '../stores/contactStore'
 import { BackgroundTimer } from '../utils/BackgroundTimer'
+import { BrekekeUtils } from '../utils/RnNativeModules'
 import { toBoolean } from '../utils/string'
 import { Pbx, PbxEvent } from './brekekejs'
 
@@ -203,6 +205,18 @@ export class PBX extends EventEmitter {
     })
     const d = await s.getCurrentDataAsync()
     d.palParamUser = s.pbxConfig['webphone.pal.param.user']
+    if (Platform.OS === 'android') {
+      BrekekeUtils.setConfig(
+        s.pbxConfig?.['webphone.call.transfer'] === 'false',
+        s.pbxConfig?.['webphone.call.park'] === 'false',
+        s.pbxConfig?.['webphone.call.video'] === 'false',
+        s.pbxConfig?.['webphone.call.speaker'] === 'false',
+        s.pbxConfig?.['webphone.call.mute'] === 'false',
+        s.pbxConfig?.['webphone.call.record'] === 'false',
+        s.pbxConfig?.['webphone.call.dtmf'] === 'false',
+        s.pbxConfig?.['webphone.call.hold'] === 'false',
+      )
+    }
     accountStore.updateAccountData(d)
     return s.pbxConfig
   }

--- a/src/components/ButtonIcon.tsx
+++ b/src/components/ButtonIcon.tsx
@@ -1,5 +1,11 @@
 import { FC } from 'react'
-import { Platform, StyleSheet, TouchableOpacityProps, View } from 'react-native'
+import {
+  Platform,
+  StyleSheet,
+  TouchableOpacityProps,
+  View,
+  ViewProps,
+} from 'react-native'
 import Svg, { Path } from 'react-native-svg'
 
 import { RnText, RnTouchableOpacity } from './Rn'
@@ -33,10 +39,11 @@ export const ButtonIcon: FC<{
   bdcolor?: string
   name?: string
   textcolor?: string
+  styleContainer?: ViewProps['style']
 }> = p => {
   const size = p.size || 15
   return (
-    <View style={css.ButtonIcon}>
+    <View style={[css.ButtonIcon, p.styleContainer]}>
       <RnTouchableOpacity
         disabled={p.disabled}
         onPress={p.onPress}

--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -32,6 +32,7 @@ import { RnText } from '../components/RnText'
 import { SmartImage } from '../components/SmartImage'
 import { v } from '../components/variables'
 import { VideoPlayer } from '../components/VideoPlayer'
+import { getAuthStore } from '../stores/authStore'
 import { Call } from '../stores/Call'
 import { callStore } from '../stores/callStore'
 import { intl } from '../stores/intl'
@@ -74,12 +75,19 @@ const css = StyleSheet.create({
     right: 0,
     bottom: 0,
   },
+  BtnFuncCalls: {
+    marginBottom: 10,
+  },
   Btns_Hidden: {
     opacity: 0,
   },
   Btns_Inner: {
     flexDirection: 'row',
     alignSelf: 'center',
+    width: Dimensions.get('screen').width - 20,
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   Btns_Space: {
     height: 20,
@@ -283,15 +291,18 @@ export class PageCallManage extends Component<{
     }
     const isHideButtons =
       !(c.withSDPControls || c.answered) && Platform.OS === 'web'
+
+    const configure = getAuthStore()?.pbxConfig
     return (
       <Container
         onPress={isVideoEnabled ? this.toggleButtons : undefined}
         style={css.Btns}
       >
         <View style={css.Btns_VerticalMargin} />
-        <View style={isHideButtons && css.Btns_Hidden}>
-          <View style={css.Btns_Inner}>
+        <View style={[css.Btns_Inner, isHideButtons && css.Btns_Hidden]}>
+          {!(configure?.['webphone.call.transfer'] === 'false') && (
             <ButtonIcon
+              styleContainer={css.BtnFuncCalls}
               disabled={!c.answered}
               bgcolor='white'
               color='black'
@@ -302,7 +313,10 @@ export class PageCallManage extends Component<{
               size={40}
               textcolor='white'
             />
+          )}
+          {!(configure?.['webphone.call.park'] === 'false') && (
             <ButtonIcon
+              styleContainer={css.BtnFuncCalls}
               disabled={!c.answered}
               bgcolor='white'
               color='black'
@@ -313,7 +327,10 @@ export class PageCallManage extends Component<{
               size={40}
               textcolor='white'
             />
+          )}
+          {!(configure?.['webphone.call.video'] === 'false') && (
             <ButtonIcon
+              styleContainer={css.BtnFuncCalls}
               disabled={!c.answered}
               bgcolor={c.localVideoEnabled ? activeColor : 'white'}
               color={c.localVideoEnabled ? 'white' : 'black'}
@@ -324,9 +341,12 @@ export class PageCallManage extends Component<{
               size={40}
               textcolor='white'
             />
-            {Platform.OS !== 'web' && (
+          )}
+          {Platform.OS !== 'web' &&
+            !(configure?.['webphone.call.speaker'] === 'false') && (
               <ButtonIcon
                 // disabled={!this.enableSpeaker}
+                styleContainer={css.BtnFuncCalls}
                 bgcolor={callStore.isLoudSpeakerEnabled ? activeColor : 'white'}
                 color={callStore.isLoudSpeakerEnabled ? 'white' : 'black'}
                 name={intl`SPEAKER`}
@@ -341,10 +361,12 @@ export class PageCallManage extends Component<{
                 textcolor='white'
               />
             )}
-          </View>
-          <View style={css.Btns_Space} />
-          <View style={css.Btns_Inner}>
+
+          {/* <View style={css.Btns_Space} /> */}
+          {/* <View style={css.Btns_Inner}> */}
+          {!(configure?.['webphone.call.mute'] === 'false') && (
             <ButtonIcon
+              styleContainer={css.BtnFuncCalls}
               disabled={!c.answered}
               bgcolor={c.muted ? activeColor : 'white'}
               color={c.muted ? 'white' : 'black'}
@@ -355,7 +377,10 @@ export class PageCallManage extends Component<{
               size={40}
               textcolor='white'
             />
+          )}
+          {!(configure?.['webphone.call.record'] === 'false') && (
             <ButtonIcon
+              styleContainer={css.BtnFuncCalls}
               disabled={!c.answered}
               bgcolor={c.recording ? activeColor : 'white'}
               color={c.recording ? 'white' : 'black'}
@@ -366,7 +391,10 @@ export class PageCallManage extends Component<{
               size={40}
               textcolor='white'
             />
+          )}
+          {!(configure?.['webphone.call.dtmf'] === 'false') && (
             <ButtonIcon
+              styleContainer={css.BtnFuncCalls}
               disabled={!(c.withSDPControls || c.answered)}
               bgcolor='white'
               color='black'
@@ -377,7 +405,10 @@ export class PageCallManage extends Component<{
               size={40}
               textcolor='white'
             />
+          )}
+          {!(configure?.['webphone.call.hold'] === 'false') && (
             <ButtonIcon
+              styleContainer={css.BtnFuncCalls}
               disabled={!c.answered}
               bgcolor={c.holding ? activeColor : 'white'}
               color={c.holding ? 'white' : 'black'}
@@ -388,8 +419,9 @@ export class PageCallManage extends Component<{
               size={40}
               textcolor='white'
             />
-          </View>
+          )}
         </View>
+        {/* </View> */}
         {n > 0 && (
           <FieldButton
             label={intl`BACKGROUND CALLS`}

--- a/src/utils/RnNativeModules.ts
+++ b/src/utils/RnNativeModules.ts
@@ -22,7 +22,16 @@ type TBrekekeUtils = {
   setLocale(locale: string): void
   onCallConnected(uuid: string): void
   onCallKeepAction(uuid: string, action: TCallkeepAction): void
-
+  setConfig(
+    hideBtnTransfer: boolean,
+    hideBtnPark: boolean,
+    hideBtnVideo: boolean,
+    hideBtnSpeaker: boolean,
+    hideBtnMute: boolean,
+    hideBtnRecord: boolean,
+    hideBtnDTMF: boolean,
+    hideBtnHold: boolean,
+  ): void
   // these methods only available on ios
   playRBT(): void
   stopRBT(): void
@@ -56,6 +65,7 @@ const Polyfill: TBrekekeUtils = {
   playRBT: () => undefined,
   stopRBT: () => undefined,
   systemUptimeMs: () => Promise.resolve(-1),
+  setConfig: () => undefined,
 }
 
 const M = NativeModules as TNativeModules


### PR DESCRIPTION
For 2.11 features,  please hide the buttons on the call screen when PBX gives the following properties with the getProductInfo method.

webphone.call.transfer=false
webphone.call.park=false
webphone.call.video=false
webphone.call.mute=false
webphone.call.record=false
webphone.call.dtmf=false
webphone.call.hold=false