### PR TITLE
Fix issue: Display name does not update last calls in Recents

### DIFF
--- a/src/stores/authStore2.ts
+++ b/src/stores/authStore2.ts
@@ -225,6 +225,19 @@ export class AuthStore {
     accountStore.saveAccountsToLocalStorageDebounced()
   }
 
+  updatePartyNameRecentCall = async (call: {
+    partyName: string
+    partyNumber: string
+  }) => {
+    const d = await this.getCurrentDataAsync()
+    if (!!!d.recentCalls?.length) {
+      return
+    }
+    d.recentCalls.map(item =>
+      item.partyNumber === call.partyNumber ? Object.assign(item, call) : item,
+    )
+    accountStore.saveAccountsToLocalStorageDebounced()
+  }
   savePbxBuddyList = async (pbxBuddyList: {
     screened: boolean
     users: (UcBuddy | UcBuddyGroup)[]

--- a/src/stores/authStore2.ts
+++ b/src/stores/authStore2.ts
@@ -21,6 +21,7 @@ import {
 } from './accountStore'
 import { authSIP } from './AuthSIP'
 import { setAuthStore } from './authStore'
+import { Call } from './Call'
 import { getCallStore } from './callStore'
 import { chatStore } from './chatStore'
 import { contactStore } from './contactStore'
@@ -225,19 +226,19 @@ export class AuthStore {
     accountStore.saveAccountsToLocalStorageDebounced()
   }
 
-  updatePartyNameRecentCall = async (call: {
-    partyName: string
-    partyNumber: string
-  }) => {
+  updatePartyNameRecentCall = async (
+    fragment: Pick<Call, 'partyNumber' | 'partyName'>,
+  ) => {
     const d = await this.getCurrentDataAsync()
-    if (!!!d.recentCalls?.length) {
+    if (!d.recentCalls?.length) {
       return
     }
-    d.recentCalls.map(item =>
-      item.partyNumber === call.partyNumber ? Object.assign(item, call) : item,
-    )
+    d.recentCalls
+      .filter(c => c.partyNumber === fragment.partyNumber)
+      .forEach(c => Object.assign(c, fragment))
     accountStore.saveAccountsToLocalStorageDebounced()
   }
+
   savePbxBuddyList = async (pbxBuddyList: {
     screened: boolean
     users: (UcBuddy | UcBuddyGroup)[]

--- a/src/stores/contactStore.ts
+++ b/src/stores/contactStore.ts
@@ -300,6 +300,15 @@ class ContactStore {
     } else {
       Object.assign(p0, p)
     }
+
+    // update display name for recent call
+    const partyNumber =
+      p.info?.$tel_mobile || p.info?.$tel_work || p.info?.$tel_home
+    if (partyNumber) {
+      const ac = getAuthStore()
+      ac.updatePartyNameRecentCall({ partyName: p.display_name, partyNumber })
+    }
+
     this.phoneBooks = [...this.phoneBooks]
   }
   @action setPhonebook = (p: Phonebook | Phonebook[]) => {


### PR DESCRIPTION
**Reproduce**
1. A make some calls to B.
2. Ext B display in A "Recents" tab.
3. A create a contact for B ext.
=> B Ext display new name.
4. A close and re-open brekeke app again.
5. A check "Recents" tab.
=> B's new display name does not update in "Recents" tab.
** Similar issue when delete/edit a contact.
** New display name apply to new call properly.