### PR TITLE
Fix issue keyboard

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -933,7 +933,9 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
   // ==========================================================================
   @Override
   public boolean dispatchKeyEvent(KeyEvent e) {
-    if (e.getKeyCode() == KeyEvent.KEYCODE_BACK || e.getKeyCode() == KeyEvent.KEYCODE_SOFT_LEFT) {
+    int k = e.getKeyCode();
+    BrekekeUtils.emit("debug", "IncomingCallActivity.onKeyDown k=" + k);
+    if (k == KeyEvent.KEYCODE_BACK || k == KeyEvent.KEYCODE_SOFT_LEFT) {
       if (BrekekeUtils.isLocked()) {
         onRequestUnlock(null);
       } else {

--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -277,7 +277,6 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
     timerTask = null;
     timer = null;
     BrekekeUtils.onActivityPauseOrDestroy(uuid, true);
-    BrekekeUtils.staticStopRingtone();
     super.onDestroy();
   }
 

--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -931,6 +931,7 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
   }
 
   // ==========================================================================
+  // Stop ringtone on any press and custom back btn handler
   @Override
   public boolean dispatchKeyEvent(KeyEvent e) {
     int k = e.getKeyCode();

--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -277,6 +277,7 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
     timerTask = null;
     timer = null;
     BrekekeUtils.onActivityPauseOrDestroy(uuid, true);
+    BrekekeUtils.staticStopRingtone();
     super.onDestroy();
   }
 
@@ -945,7 +946,7 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
       // Stop ringtone if any of the hardware key press
       BrekekeUtils.staticStopRingtone();
     }
-    return super.onKeyDown(e.getKeyCode(), e);
+    return super.dispatchKeyEvent(e);
   }
 
   // ==========================================================================

--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -935,16 +935,20 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
   @Override
   public boolean dispatchKeyEvent(KeyEvent e) {
     int k = e.getKeyCode();
-    BrekekeUtils.emit("debug", "IncomingCallActivity.onKeyDown k=" + k);
+    int a = e.getAction();
+    BrekekeUtils.emit("debug", "IncomingCallActivity.onKeyDown k=" + k + " a=" + a);
+    // Stop ringtone if any of the hardware key press
+    BrekekeUtils.staticStopRingtone();
+    // Handle back btn press, remember that this event fire twice, down/up
     if (k == KeyEvent.KEYCODE_BACK || k == KeyEvent.KEYCODE_SOFT_LEFT) {
-      if (BrekekeUtils.isLocked()) {
-        onRequestUnlock(null);
-      } else {
-        onBackPressed();
+      if (a == KeyEvent.ACTION_DOWN) {
+        if (BrekekeUtils.isLocked()) {
+          onRequestUnlock(null);
+        } else {
+          onBackPressed();
+        }
       }
-    } else {
-      // Stop ringtone if any of the hardware key press
-      BrekekeUtils.staticStopRingtone();
+      return true;
     }
     return super.dispatchKeyEvent(e);
   }

--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -931,25 +931,19 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
   }
 
   // ==========================================================================
-  // Stop ringtone if any of the hardware key press
   @Override
-  public boolean onKeyDown(int k, KeyEvent e) {
-    debug("onKeyDown k=" + k);
-    if (k == KeyEvent.KEYCODE_BACK || k == KeyEvent.KEYCODE_SOFT_LEFT) {
+  public boolean dispatchKeyEvent(KeyEvent e) {
+    if (e.getKeyCode() == KeyEvent.KEYCODE_BACK || e.getKeyCode() == KeyEvent.KEYCODE_SOFT_LEFT) {
       if (BrekekeUtils.isLocked()) {
         onRequestUnlock(null);
       } else {
         onBackPressed();
       }
     } else {
+      // Stop ringtone if any of the hardware key press
       BrekekeUtils.staticStopRingtone();
     }
-    return super.onKeyDown(k, e);
-  }
-
-  @Override
-  public boolean dispatchKeyEvent(KeyEvent e) {
-    return onKeyDown(e.getAction(), e);
+    return super.onKeyDown(e.getKeyCode(), e);
   }
 
   // ==========================================================================

--- a/android/app/src/main/java/com/brekeke/phonedev/MainActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/MainActivity.java
@@ -46,12 +46,16 @@ public class MainActivity extends ReactActivity {
   @Override
   public boolean dispatchKeyEvent(KeyEvent e) {
     int k = e.getKeyCode();
-    BrekekeUtils.emit("debug", "MainActivity.onKeyDown k=" + k);
+    int a = e.getAction();
+    BrekekeUtils.emit("debug", "MainActivity.onKeyDown k=" + k + " a=" + a);
+    // Stop ringtone if any of the hardware key press
+    BrekekeUtils.staticStopRingtone();
+    // Handle back btn press, remember that this event fire twice, down/up
     if (k == KeyEvent.KEYCODE_BACK || k == KeyEvent.KEYCODE_SOFT_LEFT) {
-      BrekekeUtils.emit("onBackPressed", "");
-    } else {
-      // incoming call press any key will stop ringtone
-      BrekekeUtils.staticStopRingtone();
+      if (a == KeyEvent.ACTION_DOWN) {
+        BrekekeUtils.emit("onBackPressed", "");
+      }
+      return true;
     }
     return super.dispatchKeyEvent(e);
   }

--- a/android/app/src/main/java/com/brekeke/phonedev/MainActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/MainActivity.java
@@ -42,7 +42,7 @@ public class MainActivity extends ReactActivity {
     }
   }
 
-  // on back pressed
+  //   on back pressed
   @Override
   public boolean dispatchKeyEvent(KeyEvent e) {
     int k = e.getKeyCode();
@@ -53,7 +53,7 @@ public class MainActivity extends ReactActivity {
       // incoming call press any key will stop ringtone
       BrekekeUtils.staticStopRingtone();
     }
-    return super.onKeyDown(e.getKeyCode(), e);
+    return super.dispatchKeyEvent(e);
   }
 
   // ==========================================================================

--- a/android/app/src/main/java/com/brekeke/phonedev/MainActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/MainActivity.java
@@ -42,7 +42,8 @@ public class MainActivity extends ReactActivity {
     }
   }
 
-  //   on back pressed
+  // ==========================================================================
+  // Stop ringtone on any press and custom back btn handler
   @Override
   public boolean dispatchKeyEvent(KeyEvent e) {
     int k = e.getKeyCode();

--- a/android/app/src/main/java/com/brekeke/phonedev/MainActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/MainActivity.java
@@ -42,31 +42,18 @@ public class MainActivity extends ReactActivity {
     }
   }
 
-  // ==========================================================================
-  // Do not exit on back pressed
+  // on back pressed
   @Override
-  public void onBackPressed() {
-    BrekekeUtils.emit("debug", "MainActivity.onBackPressed");
-    BrekekeUtils.emit("onBackPressed", "");
-  }
-
-  // ==========================================================================
-  // Stop ringtone if any of the hardware key press
-  // Same with IncomingCallActivity
-  @Override
-  public boolean onKeyDown(int k, KeyEvent e) {
+  public boolean dispatchKeyEvent(KeyEvent e) {
+    int k = e.getKeyCode();
     BrekekeUtils.emit("debug", "MainActivity.onKeyDown k=" + k);
     if (k == KeyEvent.KEYCODE_BACK || k == KeyEvent.KEYCODE_SOFT_LEFT) {
       BrekekeUtils.emit("onBackPressed", "");
     } else {
+      // incoming call press any key will stop ringtone
       BrekekeUtils.staticStopRingtone();
     }
-    return super.onKeyDown(k, e);
-  }
-
-  @Override
-  public boolean dispatchKeyEvent(KeyEvent e) {
-    return onKeyDown(e.getAction(), e);
+    return super.onKeyDown(e.getKeyCode(), e);
   }
 
   // ==========================================================================

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -8,7 +8,6 @@ import { useEffect } from 'react'
 import {
   ActivityIndicator,
   AppState,
-  BackHandler,
   Platform,
   StyleSheet,
   View,
@@ -39,7 +38,7 @@ import { RnPickerRoot } from '../stores/RnPickerRoot'
 import { RnStackerRoot } from '../stores/RnStackerRoot'
 import { userStore } from '../stores/userStore'
 import { BackgroundTimer } from '../utils/BackgroundTimer'
-import { onBackPressed, setupCallKeep } from '../utils/callkeep'
+import { setupCallKeep } from '../utils/callkeep'
 import { getAudioVideoPermission } from '../utils/getAudioVideoPermission'
 // @ts-ignore
 import { PushNotification } from '../utils/PushNotification'
@@ -86,9 +85,6 @@ const initApp = async () => {
     BackgroundTimer.setTimeout(() => RnAlert.error({ unexpectedErr }), 300)
     return false
   })
-  // Handle android hardware back button press
-  // already handle on Android native code
-  // BackHandler.addEventListener('hardwareBackPress', onBackPressed)
 
   const hasCallOrWakeFromPN =
     getCallStore().calls.length ||

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -87,7 +87,8 @@ const initApp = async () => {
     return false
   })
   // Handle android hardware back button press
-  BackHandler.addEventListener('hardwareBackPress', onBackPressed)
+  // already handle on Android native code
+  // BackHandler.addEventListener('hardwareBackPress', onBackPressed)
 
   const hasCallOrWakeFromPN =
     getCallStore().calls.length ||


### PR DESCRIPTION
Problem:

- If I use a default Samsung keyboard on my device (Samsung Galaxy A52), keys that in grey do not work, the keyboard disappears when I press any of them (ex: pressing a "delete" key) - Please see below snapshot.

- If I use other installed keyboard, the keyboard disappears when I start entering any number.

- Kill - not lock: If Adjust volume when receiving incoming call, the Brekke phone app disappears, and just hear ringing tone.
(1) Login brekeke phone and kill it.
(2) Make a call to the Brekeke phone.
=> It shows a call screen for incoming call.
(3) Press a volumn button (increase or descrease) one time on the right side of phone.
=> The PN call screen disappears, and brekeke phone displays with a regular incoming bar on top of the phone screen (NG)
Expected: PN Call screen still displays, and volumn of ringing tone is stop
(4) Press the volumn button the 2nd time.
=> The brekeke phone disappears, and ringing tone keep playing (NG)
Expected: PN Call screen still displays, and volumn of ringing tone is stop
