### PR TITLE
Fix issue: Avatar loading

### DIFF
--- a/src/components/SmartAvatarHTML.tsx
+++ b/src/components/SmartAvatarHTML.tsx
@@ -46,11 +46,9 @@ export const SmartImage = (p: { uri: string; style: object }) => {
   const onMessage = (event: WebViewMessageEvent) => {
     setStatusImageLoading(1)
   }
-
   const onLoadEnd = () => {
     setStatusImageLoading(1)
   }
-
   const onImageLoadError = () => {
     setStatusImageLoading(2)
   }

--- a/src/components/SmartAvatarHTML.tsx
+++ b/src/components/SmartAvatarHTML.tsx
@@ -68,7 +68,7 @@ export const SmartImage = (p: { uri: string; style: object }) => {
           style={[css.loading, css.full]}
         />
       )}
-      {!isImageUrl && statusImageLoading ? (
+      {!isImageUrl ? (
         <WebView
           source={{
             uri: p.uri,

--- a/src/components/SmartAvatarHTML.tsx
+++ b/src/components/SmartAvatarHTML.tsx
@@ -40,8 +40,8 @@ export const SmartImage = (p: { uri: string; style: object }) => {
   const [statusImageLoading, setStatusImageLoading] = useState(0)
   useEffect(() => {
     setStatusImageLoading(0)
+    console.log(`SmartImage url=${p.uri}`)
   }, [p.uri])
-  console.log(`SmartImage url=${p.uri}`)
 
   const onMessage = (event: WebViewMessageEvent) => {
     setStatusImageLoading(1)
@@ -68,7 +68,7 @@ export const SmartImage = (p: { uri: string; style: object }) => {
           style={[css.loading, css.full]}
         />
       )}
-      {!isImageUrl ? (
+      {!isImageUrl && statusImageLoading ? (
         <WebView
           source={{
             uri: p.uri,

--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -385,7 +385,6 @@ class PageCallManage extends Component<{
         </View>
       )
     }
-
     return (
       <>
         {c.localVideoEnabled && this.renderVideo()}
@@ -434,23 +433,16 @@ class PageCallManage extends Component<{
       ? { flex: 1, maxHeight: Dimensions.get('window').height / 2 - 20 }
       : { flex: 1 }
     const styleViewAvatar = isLarge ? styleBigAvatar : css.smallAvatar
-
+    const smartImageUrl = `${c.answered ? c.talkingImageUrl : c.partyImageUrl}`
     return (
       <View style={[css.Image_wrapper, { flex: 1 }]}>
         {isShowAvatar ? (
           <View style={styleViewAvatar}>
-            {c.answered && (
-              <SmartImage
-                uri={`${c.talkingImageUrl}`}
-                style={{ flex: 1, aspectRatio: 1 }}
-              />
-            )}
-            {!c.answered && (
-              <SmartImage
-                uri={`${c.partyImageUrl}`}
-                style={{ flex: 1, aspectRatio: 1 }}
-              />
-            )}
+            <SmartImage
+              key={smartImageUrl}
+              uri={smartImageUrl}
+              style={{ flex: 1, aspectRatio: 1 }}
+            />
           </View>
         ) : (
           <View style={{ flex: 1 }} />

--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -439,12 +439,14 @@ class PageCallManage extends Component<{
           <View style={styleViewAvatar}>
             {c.answered && (
               <SmartImage
+                key={c.talkingImageUrl}
                 uri={`${c.talkingImageUrl}`}
                 style={{ flex: 1, aspectRatio: 1 }}
               />
             )}
             {!c.answered && (
               <SmartImage
+                key={c.partyImageUrl}
                 uri={`${c.partyImageUrl}`}
                 style={{ flex: 1, aspectRatio: 1 }}
               />

--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -385,6 +385,7 @@ class PageCallManage extends Component<{
         </View>
       )
     }
+
     return (
       <>
         {c.localVideoEnabled && this.renderVideo()}
@@ -433,14 +434,23 @@ class PageCallManage extends Component<{
       ? { flex: 1, maxHeight: Dimensions.get('window').height / 2 - 20 }
       : { flex: 1 }
     const styleViewAvatar = isLarge ? styleBigAvatar : css.smallAvatar
+
     return (
       <View style={[css.Image_wrapper, { flex: 1 }]}>
         {isShowAvatar ? (
           <View style={styleViewAvatar}>
-            <SmartImage
-              uri={`${!c.answered ? c.partyImageUrl : c.talkingImageUrl}`}
-              style={{ flex: 1, aspectRatio: 1 }}
-            />
+            {c.answered && (
+              <SmartImage
+                uri={`${c.talkingImageUrl}`}
+                style={{ flex: 1, aspectRatio: 1 }}
+              />
+            )}
+            {!c.answered && (
+              <SmartImage
+                uri={`${c.partyImageUrl}`}
+                style={{ flex: 1, aspectRatio: 1 }}
+              />
+            )}
           </View>
         ) : (
           <View style={{ flex: 1 }} />

--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -433,16 +433,22 @@ class PageCallManage extends Component<{
       ? { flex: 1, maxHeight: Dimensions.get('window').height / 2 - 20 }
       : { flex: 1 }
     const styleViewAvatar = isLarge ? styleBigAvatar : css.smallAvatar
-    const smartImageUrl = `${c.answered ? c.talkingImageUrl : c.partyImageUrl}`
     return (
       <View style={[css.Image_wrapper, { flex: 1 }]}>
         {isShowAvatar ? (
           <View style={styleViewAvatar}>
-            <SmartImage
-              key={smartImageUrl}
-              uri={smartImageUrl}
-              style={{ flex: 1, aspectRatio: 1 }}
-            />
+            {c.answered && (
+              <SmartImage
+                uri={`${c.talkingImageUrl}`}
+                style={{ flex: 1, aspectRatio: 1 }}
+              />
+            )}
+            {!c.answered && (
+              <SmartImage
+                uri={`${c.partyImageUrl}`}
+                style={{ flex: 1, aspectRatio: 1 }}
+              />
+            )}
           </View>
         ) : (
           <View style={{ flex: 1 }} />

--- a/src/stores/Call.ts
+++ b/src/stores/Call.ts
@@ -68,7 +68,8 @@ export class Call {
     if (options) {
       delete options.ignoreNav
     }
-    this.answered = true
+    // already update on upsert Call
+    // this.answered = true
     this.store.currentCallId = this.id
     // Hold other calls
     this.store.calls

--- a/src/stores/Call.ts
+++ b/src/stores/Call.ts
@@ -68,8 +68,7 @@ export class Call {
     if (options) {
       delete options.ignoreNav
     }
-    // already update on upsert Call
-    // this.answered = true
+    this.answered = true
     this.store.currentCallId = this.id
     // Hold other calls
     this.store.calls


### PR DESCRIPTION
**Reproduce:**
1. Set dialplan with different webview sources in RINGING and TALKING, see howto_3.14.6.22onward. RINGING is webview with confirm navigation option.
2. B log in brekeke with disable push notificaiton. A dial B number and B ringing with popup on top screen.
3. B click on the popup on top screen.
=> B screen show avatar source set in PBX with tag X-PBX-IMAGE-RINGING
4. B do some change on avatar screen. (input info) 
=> Avatar change to new state B1.
5. B answer the call
=> A&B talking well.
=> In IOS: B screen show avatar source set in PBX with tag X-PBX-IMAGE-TALKING.
=> In Android: Confirm Navigation is pop up with 2 options: ""Stay on this page"" and ""Leave this page"".
6. B click on ""Stay on this page""
Issue: B screen hanging in avatar in state B1.
Expect: B screen show well in state B1.