### PR TITLE
Fix issue: update load phonebook after login success

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -54,6 +54,7 @@ class Api {
     const s = getAuthStore()
     s.pbxState = 'success'
     s.pbxTotalFailure = 0
+    contactStore.loadContacts()
     authSIP.authWithCheck()
     await waitSip()
     await pbx.getConfig()

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -54,7 +54,6 @@ class Api {
     const s = getAuthStore()
     s.pbxState = 'success'
     s.pbxTotalFailure = 0
-    contactStore.loadContacts()
     authSIP.authWithCheck()
     await waitSip()
     await pbx.getConfig()
@@ -62,6 +61,7 @@ class Api {
     if (!cp) {
       return
     }
+    contactStore.loadContacts()
     // load list local  when pbx start
     // set default pbxLocalAllUsers = true
     if (cp.pbxLocalAllUsers === undefined) {

--- a/src/pages/PageContactPhonebook.tsx
+++ b/src/pages/PageContactPhonebook.tsx
@@ -158,16 +158,15 @@ export class PageContactPhonebook extends Component {
   }
 
   updateSearchText = (v: string) => {
-    // TODO use debounced value to perform data filter
     contactStore.phonebookSearchTerm = v
-    this.updateListPhoneBook()
+    this.loadContactsDebounced()
     contactStore.selectedContactIds = {}
   }
-
-  updateListPhoneBook = debounce(() => {
+  loadContactsDebounced = debounce(() => {
     contactStore.offset = 0
     contactStore.loadContacts()
   }, 500)
+
   onDelete = async () => {
     if (isEmpty(contactStore.selectedContactIds)) {
       return

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -24,11 +24,12 @@ const wait = (
     return
   }
   const id = BackgroundTimer.setInterval(() => {
-    const enoughTimePassed = Date.now() - at > time
-    const isConnected = authStore[name] === 'success'
-    if (enoughTimePassed || isConnected) {
+    if (authStore[name] === 'success') {
       BackgroundTimer.clearInterval(id)
-      fn(isConnected)
+      fn(true)
+    } else if (Date.now() - at > time) {
+      BackgroundTimer.clearInterval(id)
+      fn(false)
     }
   }, 500)
 }

--- a/src/stores/contactStore.ts
+++ b/src/stores/contactStore.ts
@@ -88,7 +88,6 @@ class ContactStore {
         if (!arr) {
           return
         }
-
         this.setPhonebook(arr as Phonebook[])
         this.hasLoadmore = arr.length === this.numberOfContactsPerPage
       })


### PR DESCRIPTION
1. A (android/ios)&B talking. A phonebook define display name C1 for C ext
2. A click on transfer.
3. A swithc to keypad tab.
4. A enter C ext and call button (with arrow icon)
5. A's transferring screen show C1 display name C ext in A's phonebook.