### PR TITLE
Fix issue: task incoming call activity still show 

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,6 +44,7 @@
       android:launchMode="standard"
       android:showOnLockScreen="true"
       android:screenOrientation="sensorPortrait"
+      android:autoRemoveFromRecents="true"
     />
     <activity
       android:name=".ExitActivity"


### PR DESCRIPTION
(1) login brekeke phone, and receive the 1st call.
(2) disconnect call.
=> The PN talking screen still exist in background list of device 
(3) repease step1, 2 for more calls. 
=> multiple talking screens exist in device's background.
There screens will never clean.