### PR TITLE
Fix issue #599, # 598

### DIFF
--- a/src/components/AccountCreateForm.tsx
+++ b/src/components/AccountCreateForm.tsx
@@ -82,6 +82,7 @@ export const AccountCreateForm: FC<{
         onConfirm: () => {
           $.set('account', (p: Account) => {
             p.parks = p.parks?.filter((p0, i0) => i0 !== i)
+            p.parkNames = p.parkNames?.filter((p0, i0) => i0 !== i)
             return p
           })
         },

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -260,6 +260,9 @@ export const Field: FC<
       </View>
     )
   }
+  // handle enable/disable input Park
+  const disablePark = props.type === 'PARK' && props.disabled
+
   const $0 = useStore(() => ({
     observable: {
       isFocusing: false,
@@ -516,6 +519,7 @@ export const Field: FC<
           >
             {props.inputElement || (
               <RnTextInput
+                editable={!disablePark}
                 disabled
                 maxLength={props?.maxLength || 100000}
                 secureTextEntry={!!(props.secureTextEntry && props.value)}
@@ -525,7 +529,9 @@ export const Field: FC<
                 }
               />
             )}
-            {!$.isFocusing && <View style={StyleSheet.absoluteFill} />}
+            {!$.isFocusing && disablePark && (
+              <View style={StyleSheet.absoluteFill} />
+            )}
           </View>
         }
         {/* Fix form auto fill style on web */}


### PR DESCRIPTION
#599:
If deleting a park number then labels of the other numbers change unexpectedly.
![CleanShot 2023-05-10 at 11 59 57@2x](https://github.com/brekekesoftware/brekekephone/assets/5568604/19ac2e43-55b8-4a94-a0b9-9da7d6933a14)

#598:
While creating a park number, it is not able to change "New Park" or "label" fields once left the fields.
<img width="475" alt="CleanShot 2023-05-10 at 12 01 07@2x" src="https://github.com/brekekesoftware/brekekephone/assets/5568604/f908dfc3-3a9e-49a5-a208-a7ea43d2aa71">
