### PR TITLE
Fix issue 725, 727, 728, 731

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -10,6 +10,8 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
 import android.net.Uri;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.util.DisplayMetrics;
@@ -708,12 +710,17 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
   public void onRequestPermissionsResult(
       int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
     super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    int isPermBluetoothConnect = PackageManager.PERMISSION_GRANTED;
+    // https://developer.android.com/guide/topics/connectivity/bluetooth/permissions
+    if (VERSION.SDK_INT >= VERSION_CODES.S) {
+      isPermBluetoothConnect = grantResults[2];
+    }
     switch (requestCode) {
       case MY_PERMISSIONS_REQUEST_MICROPHONE_CAMERA:
         if (grantResults.length == 3
             && grantResults[0] == PackageManager.PERMISSION_GRANTED
             && grantResults[1] == PackageManager.PERMISSION_GRANTED
-            && grantResults[2] == PackageManager.PERMISSION_GRANTED) {
+            && isPermBluetoothConnect == PackageManager.PERMISSION_GRANTED) {
           handleClickAnswerCall();
         } else {
           debug("MY_PERMISSIONS_REQUEST_MICROPHONE_CAMERA failed");

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -181,8 +181,6 @@ const initApp = async () => {
 
 let alreadyInitApp = false
 PushNotification.register(async () => {
-  console.log('dev::', 'PushNotification.register')
-
   if (alreadyInitApp) {
     return
   }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -42,11 +42,7 @@ import { userStore } from '../stores/userStore'
 import { BackgroundTimer } from '../utils/BackgroundTimer'
 import { setupCallKeep } from '../utils/callkeep'
 import { getAudioVideoPermission } from '../utils/getAudioVideoPermission'
-import {
-  permForCall,
-  permNotifications,
-  permReadPhoneNumber,
-} from '../utils/permissions'
+import { permForCall, permReadPhoneNumber } from '../utils/permissions'
 // @ts-ignore
 import { PushNotification } from '../utils/PushNotification'
 import { registerOnUnhandledError } from '../utils/registerOnUnhandledError'
@@ -64,8 +60,6 @@ import { RnTouchableOpacity } from './RnTouchableOpacity'
 import { v } from './variables'
 
 const initApp = async () => {
-  permNotifications()
-
   await intlStore.wait()
   const s = getAuthStore()
   const cs = getCallStore()
@@ -187,6 +181,8 @@ const initApp = async () => {
 
 let alreadyInitApp = false
 PushNotification.register(async () => {
+  console.log('dev::', 'PushNotification.register')
+
   if (alreadyInitApp) {
     return
   }

--- a/src/utils/PushNotification.android.ts
+++ b/src/utils/PushNotification.android.ts
@@ -10,6 +10,7 @@ import {
 
 import { intlDebug } from '../stores/intl'
 import { RnAlert } from '../stores/RnAlert'
+import { permNotifications } from './permissions'
 import { parse } from './PushNotification-parse'
 import { BrekekeUtils } from './RnNativeModules'
 
@@ -47,6 +48,7 @@ export const PushNotification = {
   },
   register: async (initApp: Function) => {
     try {
+      await permNotifications()
       initApp()
       const hasPermissions: boolean =
         await Notifications.isRegisteredForRemoteNotifications()
@@ -70,9 +72,9 @@ export const PushNotification = {
 
       // set notification channel for normal case
       Notifications.setNotificationChannel({
-        // have to set channel default
+        // have to set channel: channel_01. It is default
         // https://github.com/wix/react-native-notifications/issues/869#issuecomment-1157869452
-        channelId: 'default',
+        channelId: 'channel_01',
         name: 'Brekeke Phone',
         importance: 5,
         description: 'Brekeke Phone notification channel',


### PR DESCRIPTION
# 725
(1) Delete the user push record in Push Notification > Devices if ít's existing.
(2) Install brekeke app 2.12.2 in android13.
(3) Log in user A with allowed all requests.
Issue: No record user A in Push Notification > Devices. User cannot receive push call.
** Log out/log in does not help.
** Kill app/re-open help to fix it. 
# 727
(1) Android13 A log in brekeke phone.
(2) B make a call to A.
(3) While A ringing, B disconnect call.
Issue: No miss call notification in A screen.
Expect: Miss call notification appear on top A screen.
** Android 10 get the same issue
# 728 
(1) Android13 A log in brekeke phone.
(2) B make a call to A.
(3) While A ringing, B disconnect call.
Issue: No miss call notification in A screen.
Expect: Miss call notification appear on top A screen.
** Android 10 get the same issue
# 731
"(1) Android 10 A log in brekeke phone.
(2) B make call to A.
=> A ringing and A screen show ""Answer"" and ""Reject"" button
(3) A click on ""Answer"" button
Issue: Nothing happen. A still ringing.
** If A change to Call in app screen (click on ""back"" button in phone) and click Answer, A answer the call well.
** Does not happen in Android 13."