### PR TITLE
Fix issue: Button function disappear on call screen

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -737,6 +737,9 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
   }
 
   public void onBtnAnswerClick(View v) {
+    if (answered) {
+      return;
+    }
     if (checkAndRequestPermissions()) {
       handleClickAnswerCall();
     }


### PR DESCRIPTION
- App foreground => B calls A => A receive incoming call => A answer call => Button function call disappear on manage call screen