### PR TITLE
Fix issue: White screen with loading on top screen after end a outgoing call

### DIFF
--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -253,6 +253,12 @@ class PageCallManage extends Component<{
   }
   componentWillUnmount() {
     getCallStore().onCallKeepAction()
+    // with case end outgoing call, the incomingcall will call onPageCallManage
+    const { call } = this.props
+    if (!call.incoming) {
+      getCallStore().prevDisplayingCallId = ''
+    }
+
     this.appStateSubscription?.remove()
   }
 


### PR DESCRIPTION
A make outgoing call to B, AB talking => A receive incoming call from C, AC talking => A change to AB talking => B end call => AC display loading. When click Back button, will go to Callmanage screen 

Expect: App will display Call Manage screen when B end call