### PR TITLE
Fix issue 738: Functions to send/receive files in UC chat does not work

### DIFF
--- a/src/utils/pickFile.ts
+++ b/src/utils/pickFile.ts
@@ -1,22 +1,12 @@
 import { Platform } from 'react-native'
 import DocumentRnPicker from 'react-native-document-picker'
 import RNFS from 'react-native-fs'
-import {
-  Asset,
-  launchCamera,
-  launchImageLibrary,
-} from 'react-native-image-picker'
+import { launchCamera, launchImageLibrary } from 'react-native-image-picker'
 import { v4 as newUuid } from 'uuid'
 
 import { RnPicker } from '../stores/RnPicker'
 import { onPickFileNativeError, pickFileNativeOptions } from './pickFile.web'
 
-const getFileObject = (assets: Asset[] | undefined) => {
-  if (!assets || !assets.length) {
-    return
-  }
-  return assets[0]
-}
 const actionSheetHandlers = [
   () =>
     new Promise((resolve, reject) => {
@@ -26,12 +16,12 @@ const actionSheetHandlers = [
           cameraType: 'back',
           saveToPhotos: false,
         },
-        res =>
-          res.didCancel
+        r =>
+          r.didCancel
             ? resolve(null)
-            : res.errorMessage
-            ? reject(res.errorMessage)
-            : resolve(getFileObject(res.assets)),
+            : r.errorMessage
+            ? reject(r.errorMessage)
+            : resolve(r.assets?.[0]),
       )
     }),
   () =>
@@ -41,12 +31,12 @@ const actionSheetHandlers = [
           mediaType: 'video',
           cameraType: 'back',
         },
-        res =>
-          res.didCancel
+        r =>
+          r.didCancel
             ? resolve(null)
-            : res.errorMessage
-            ? reject(res.errorMessage)
-            : resolve(getFileObject(res.assets)),
+            : r.errorMessage
+            ? reject(r.errorMessage)
+            : resolve(r.assets?.[0]),
       )
     }),
   () =>
@@ -57,12 +47,12 @@ const actionSheetHandlers = [
           assetRepresentationMode: 'auto',
           quality: 1,
         },
-        res =>
-          res.didCancel
+        r =>
+          r.didCancel
             ? resolve(null)
-            : res.errorMessage
-            ? reject(res.errorMessage)
-            : resolve(getFileObject(res.assets)),
+            : r.errorMessage
+            ? reject(r.errorMessage)
+            : resolve(r.assets?.[0]),
       )
     }),
   () =>


### PR DESCRIPTION
1. A&B log in brekeke phone with UC chat enable.
2. In User, A click on B and select "attachment" button at bottom left corner.
Issue: All functions (take a new photo/video/library/more) don't work. See error in #738
<img width="589" alt="CleanShot 2023-08-04 at 21 18 41@2x" src="https://github.com/brekekesoftware/brekekephone/assets/5568604/d78a51da-f568-4b9e-853e-7a16518a180b">

**Issue occur in both private/group chat. 