### PR TITLE
Fix issue 746: Brekeke App cannot use after user leave group chat.

### DIFF
--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1,6 +1,6 @@
 import PushNotificationIOS from '@react-native-community/push-notification-ios'
 import { sortBy, uniqBy } from 'lodash'
-import { computed, observable } from 'mobx'
+import { action, computed, observable } from 'mobx'
 import { AppState, Platform } from 'react-native'
 import { Notifications } from 'react-native-notifications'
 
@@ -439,7 +439,7 @@ class ChatStore {
     }
     this.groups = [...this.groups]
   }
-  removeGroup = (id: string) => {
+  @action removeGroup = (id: string) => {
     delete this.messagesByThreadId[id]
     delete this.threadConfig[id]
     this.groups = this.groups.filter(gr => gr.id !== id)


### PR DESCRIPTION
(1) Android13 A log in brekeke phone and join in a group chat.
(2) In group chat, A click on "Options" and select "Leave group"
Existing Issue (#614): A does not leave group chat properly. A screen is hanging in group chat, cannot do anything.
(3) B make a call to A.
=> A receive PN call and answer.
Issue: Call does not connect well. A screen keeps showing connecting.
(4) A click on disconnect 
=> A back to group chat session.
(5) A kill brekeke app in background and re-open it again.
Issue: Brekeke app cannot load properly. It's hanging at brekeke logo.

** Go to Phone settings > apps > brekeke app > select "force stop" then re-open brekeke app properly.