### PR TITLE
Fix issue 743: double PN on 1 devices with multiple phoneId

### DIFF
--- a/src/stores/accountStore.ts
+++ b/src/stores/accountStore.ts
@@ -221,13 +221,19 @@ class AccountStore {
     // for eg: pn data doesnt have all the fields to compare
     return accountStore.accounts.find(_ => compareAccount(_, a))
   }
-  findByPn = (n: ParsedPn) =>
-    this.find({
+  findByPn = (n: ParsedPn) => {
+    const phoneId = n['phone.id']
+      .replace(`${n.tenant}_${n.to}_phone`, '')
+      .replace('_webphone', '')
+
+    return this.find({
       pbxUsername: n.to,
       pbxTenant: n.tenant,
       pbxHostname: n.pbxHostname,
       pbxPort: n.pbxPort,
+      pbxPhoneIndex: phoneId,
     })
+  }
 
   findData = async (a?: AccountUnique) => {
     await storagePromise
@@ -281,7 +287,7 @@ class AccountStore {
 
 export type AccountUnique = Pick<
   Account,
-  'pbxUsername' | 'pbxTenant' | 'pbxHostname' | 'pbxPort'
+  'pbxUsername' | 'pbxTenant' | 'pbxHostname' | 'pbxPort' | 'pbxPhoneIndex'
 >
 export const getAccountUniqueId = (a: AccountUnique) =>
   jsonStableStringify({
@@ -303,7 +309,8 @@ export const compareAccount = (p1: { pbxUsername: string }, p2: object) => {
     compareField(p1, p2, 'pbxUsername') &&
     compareField(p1, p2, 'pbxTenant') &&
     compareField(p1, p2, 'pbxHostname') &&
-    compareField(p1, p2, 'pbxPort')
+    compareField(p1, p2, 'pbxPort') &&
+    compareField(p1, p2, 'pbxPhoneIndex')
   )
 }
 


### PR DESCRIPTION
Step: 
1- login account A1 with phoneID 1
2- logout then login account A1 with phoneId 2
3- login account A1 with phoneID 1 again.

When a call just arrived.
- Quickly answer the incoming call (1 ring), the call is connected but also see another call was declined on call screen.
Check snapshot.
- Quickly reject the incoming call (1 ring), it shows the call is declined but another call still ring on call screen. During this time it cannot receive new incoming call properly.
- Cancel the incoming calls (after 1 or 2 rinings), it shows the call is ended, but keep showing another call ringing on call screen. During this time it cannot receive new incoming call properly.

*** The issue also occur if pickup after some ringings. It would be easy to see the issue when pickup it quickly.