### PR TITLE
Fix issue 615, 642, 648: no-voice when kill/lock screen

### DIFF
--- a/ios/BrekekePhone/AppDelegate.swift
+++ b/ios/BrekekePhone/AppDelegate.swift
@@ -1,8 +1,10 @@
+import AVFAudio
 import Combine
 import Foundation
 import SwiftUI
 import UIKit
 import UserNotifications
+import WebRTC
 
 @UIApplicationMain
 class AppDelegate: NSObject, UIApplicationDelegate, PKPushRegistryDelegate,
@@ -112,6 +114,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, PKPushRegistryDelegate,
       .didReceiveIncomingPush(with: payload,
                               forType: (type as NSString) as String,
                               callkeepUuid: uuid)
+
     // config RNCallKeep
     AppDelegate.reportNewIncomingCall(
       uuid: uuid,
@@ -228,6 +231,11 @@ class AppDelegate: NSObject, UIApplicationDelegate, PKPushRegistryDelegate,
     if callerName == nil {
       callerName = "Loading..."
     }
+    // To fix no-voice with case multiple call and lock screen
+    RTCAudioSession.sharedInstance()
+      .audioSessionDidDeactivate(AVAudioSession.sharedInstance())
+    RTCAudioSession.sharedInstance().isAudioEnabled = false
+
     RNCallKeep.reportNewIncomingCall(uuid,
                                      handle: "Brekeke Phone",
                                      handleType: "generic",

--- a/ios/BrekekePhone/AppDelegate.swift
+++ b/ios/BrekekePhone/AppDelegate.swift
@@ -232,9 +232,9 @@ class AppDelegate: NSObject, UIApplicationDelegate, PKPushRegistryDelegate,
       callerName = "Loading..."
     }
     // To fix no-voice with case multiple call and lock screen
-    RTCAudioSession.sharedInstance()
-      .audioSessionDidDeactivate(AVAudioSession.sharedInstance())
-    RTCAudioSession.sharedInstance().isAudioEnabled = false
+//    RTCAudioSession.sharedInstance()
+//      .audioSessionDidDeactivate(AVAudioSession.sharedInstance())
+//    RTCAudioSession.sharedInstance().isAudioEnabled = false
 
     RNCallKeep.reportNewIncomingCall(uuid,
                                      handle: "Brekeke Phone",

--- a/src/utils/callkeep.ts
+++ b/src/utils/callkeep.ts
@@ -105,7 +105,7 @@ export const setupCallKeep = async () => {
     } else {
       cs.setCalleeRejected({ callkeepUuid: uuid })
       cs.onCallKeepEndCall(uuid)
-      BrekekeUtils.webrtcSetAudioEnabled(true)
+      // BrekekeUtils.webrtcSetAudioEnabled(true)
     }
 
     // try to setup callkeep on each endcall if not yet
@@ -155,6 +155,7 @@ export const setupCallKeep = async () => {
     if (c && c.holding !== e.hold) {
       c.toggleHoldWithCheck()
     }
+    BrekekeUtils.webrtcSetAudioEnabled(!e.hold)
   }
   const didPerformDTMFAction = (e: EventsPayload['didPerformDTMFAction']) => {
     const uuid = e.callUUID.toUpperCase()

--- a/src/utils/callkeep.ts
+++ b/src/utils/callkeep.ts
@@ -105,7 +105,9 @@ export const setupCallKeep = async () => {
     } else {
       cs.setCalleeRejected({ callkeepUuid: uuid })
       cs.onCallKeepEndCall(uuid)
+      BrekekeUtils.webrtcSetAudioEnabled(true)
     }
+
     // try to setup callkeep on each endcall if not yet
     setupCallKeepWithCheck()
   }


### PR DESCRIPTION
### 615:
"1. A log in brekeke and lock phone screen.
2. B call to A and A answer
=> A&B talking well.
3. C call to A.
=> A screen appear 3 option: end&accept, Reject, hold&accept.
4. A press on hold&accept button
Issue: A&C silient call
** On/off speaker button recover the silent issue.

Rate 100%"

### 642:
Steps:
1. Open brekeke phone (user A) and kill it, then lock phone's screen
2. Make the 1st call (video call) to A.
3. A answers the call but dont unlock phone's screen.
4. While talking, A receives the second incoming call.
5. A selects Hold/accept (wait after 1 or 2 ringing tones)
=> The 1st call is putted on hold. But, the second call cannot be connected, its caller keeps hearing ringing tone. And after ringing timeout, the second call is disconnected.
Somtime, the second call is connected, but it does not have voice at both sides.

### 648:
"1) A (IOS15/iphone7) log in brekeke phone then kill app and lock screen.
(2) B call to A. A answer and talking well.
(3) While A&B are talking, C call to A.
(4) A see 3 buttons on screen. 
(5) A click on ""Hold&Aceept"" button and move the phone close to ear immediately (phone screen off)
Issue: A&C is connect but silient call.

** In step 5, if A click on ""Hold&Aceept"" and keep phone screen on in 2-3s, A&C connect and talk well.
** Issue occur with iphone7 only so far. Do similar test with iphone SE does not get the issue.
*** Issue was found on iPhone SE 2nd gen"