### PR TITLE
Fix issue switch call via task manager

### DIFF
--- a/src/utils/callkeep.ts
+++ b/src/utils/callkeep.ts
@@ -276,7 +276,11 @@ export const setupCallKeep = async () => {
   eventEmitter.addListener('switchCall', (uuid: string) => {
     const cs = getCallStore()
     const c = cs.calls.find(i => i.callkeepUuid === uuid)
-    if (!c || c.id === cs.getOngoingCall()?.id) {
+    if (
+      !c ||
+      c.id === cs.getOngoingCall()?.id ||
+      !cs.getOngoingCall()?.answered
+    ) {
       return
     }
     cs.onSelectBackgroundCall(c)


### PR DESCRIPTION
(1) Android receive the first incoming call.
(2) While talking, the second incoming call arrives.
=> It shows 2 talking screens (by touching home icon to show all runing applications)
(3) Switching to other screens in background.
=> After that the call is dropped.

*** in other screens, some operation does not work well like press hold/transfer,..