### PR TITLE
Fix issue: App don't receive PN incoming call with app killed state mode

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/BrekekeMessagingService.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/BrekekeMessagingService.java
@@ -32,12 +32,7 @@ public class BrekekeMessagingService extends FcmInstanceIdListenerService {
 
   @Override
   public void onMessageReceived(RemoteMessage remoteMessage) {
-    // construct and load our normal React JS code bundle
-    ReactInstanceManager rim =
-        ((ReactApplication) getApplication()).getReactNativeHost().getReactInstanceManager();
-    if (!rim.hasStartedCreatingInitialContext()) {
-      rim.createReactContextInBackground();
-    }
+
     BrekekeUtils.onFcmMessageReceived(this, remoteMessage.getData());
 
     if (initialNotifications == null) {
@@ -51,5 +46,11 @@ public class BrekekeMessagingService extends FcmInstanceIdListenerService {
     }
 
     super.onMessageReceived(remoteMessage);
+    // construct and load our normal React JS code bundle
+    ReactInstanceManager rim =
+        ((ReactApplication) getApplication()).getReactNativeHost().getReactInstanceManager();
+    if (!rim.hasStartedCreatingInitialContext()) {
+      rim.createReactContextInBackground();
+    }
   }
 }

--- a/android/app/src/main/java/com/brekeke/phonedev/BrekekeMessagingService.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/BrekekeMessagingService.java
@@ -32,7 +32,6 @@ public class BrekekeMessagingService extends FcmInstanceIdListenerService {
 
   @Override
   public void onMessageReceived(RemoteMessage remoteMessage) {
-
     BrekekeUtils.onFcmMessageReceived(this, remoteMessage.getData());
 
     if (initialNotifications == null) {
@@ -46,6 +45,7 @@ public class BrekekeMessagingService extends FcmInstanceIdListenerService {
     }
 
     super.onMessageReceived(remoteMessage);
+
     // construct and load our normal React JS code bundle
     ReactInstanceManager rim =
         ((ReactApplication) getApplication()).getReactNativeHost().getReactInstanceManager();


### PR DESCRIPTION
# BrekekePhone may not receive calls.
If you follow the steps below, it will occur 100% of the time.
It occurs only on android.
a. Start the device (smart phone).
b. Launch the BrekekePhone app.
c. Slide BrekekePhone app from the app list to exit.
d. Call BrekekePhone.