### PR TITLE
Fix issue 770: Call menu switches between hold/unhold without control after tried to touch Hold button multi times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix ios apns token not resolve properly
 - Fix uc should load buddy list case receiving call while connecting (issue 769)
+- Fix hold button should not allow to toggle multiple times immediately (issue 770)
 - Embed:
   - Fix global web phone css injection
 

--- a/src/components/ButtonIcon.tsx
+++ b/src/components/ButtonIcon.tsx
@@ -1,5 +1,6 @@
-import { FC } from 'react'
+import { FC, useState } from 'react'
 import {
+  ActivityIndicator,
   Platform,
   StyleSheet,
   TouchableOpacityProps,
@@ -40,13 +41,27 @@ export const ButtonIcon: FC<{
   name?: string
   textcolor?: string
   styleContainer?: ViewProps['style']
+  msLoading?: number
 }> = p => {
   const size = p.size || 15
+  const [isLoading, setLoading] = useState(false)
+  const onPressBtn = () => {
+    if (p.msLoading) {
+      setLoading(true)
+      setTimeout(() => {
+        setLoading(false)
+      }, p.msLoading)
+    }
+
+    if (p.onPress) {
+      p.onPress()
+    }
+  }
   return (
     <View style={[css.ButtonIcon, p.styleContainer]}>
       <RnTouchableOpacity
-        disabled={p.disabled}
-        onPress={p.onPress}
+        disabled={isLoading || p.disabled}
+        onPress={onPressBtn}
         style={[
           css.ButtonIcon_Btn,
           p.style,
@@ -56,10 +71,15 @@ export const ButtonIcon: FC<{
           { borderColor: p.bdcolor },
         ]}
       >
-        <Svg height={size} viewBox='0 0 24 24' width={size}>
-          <Path d={p.path} fill={p.color || 'black'} />
-        </Svg>
+        {isLoading ? (
+          <ActivityIndicator style={{ width: size, height: size }} />
+        ) : (
+          <Svg height={size} viewBox='0 0 24 24' width={size}>
+            <Path d={p.path} fill={p.color || 'black'} />
+          </Svg>
+        )}
       </RnTouchableOpacity>
+
       {p.name && (
         <RnText
           small

--- a/src/components/ButtonIcon.tsx
+++ b/src/components/ButtonIcon.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native'
 import Svg, { Path } from 'react-native-svg'
 
+import { BackgroundTimer } from '../utils/BackgroundTimer'
 import { RnText, RnTouchableOpacity } from './Rn'
 import { v } from './variables'
 
@@ -43,25 +44,23 @@ export const ButtonIcon: FC<{
   styleContainer?: ViewProps['style']
   msLoading?: number
 }> = p => {
-  const size = p.size || 15
   const [isLoading, setLoading] = useState(false)
-  const onPressBtn = () => {
+  const onBtnPress = () => {
     if (p.msLoading) {
       setLoading(true)
-      setTimeout(() => {
+      BackgroundTimer.setTimeout(() => {
+        // TODO possible react warning memory leak set state after unmount
         setLoading(false)
       }, p.msLoading)
     }
-
-    if (p.onPress) {
-      p.onPress()
-    }
+    p.onPress?.()
   }
+  const size = p.size || 15
   return (
     <View style={[css.ButtonIcon, p.styleContainer]}>
       <RnTouchableOpacity
         disabled={isLoading || p.disabled}
-        onPress={onPressBtn}
+        onPress={onBtnPress}
         style={[
           css.ButtonIcon_Btn,
           p.style,
@@ -79,7 +78,6 @@ export const ButtonIcon: FC<{
           </Svg>
         )}
       </RnTouchableOpacity>
-
       {p.name && (
         <RnText
           small

--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -657,6 +657,7 @@ class PageCallManage extends Component<{
               onPress={c.toggleHoldWithCheck}
               path={c.holding ? mdiPlayCircle : mdiPauseCircle}
               size={40}
+              msLoading={1000}
               textcolor='white'
             />
           )}


### PR DESCRIPTION
Step:
Create a call. On the Call manage screen, press the hold button multiple times.

Problem: 
The hold action is repeated continuously and the application cannot be controlled.