### PR TITLE
#776: Voice to 2 sides when answer 2nd call in transferring 1st call

### DIFF
--- a/src/stores/Call.ts
+++ b/src/stores/Call.ts
@@ -260,6 +260,13 @@ export class Call {
       .stopTalkerTransfer(this.pbxTenant, this.pbxTalkerId)
       .catch(this.onStopTransferringFailure)
   }
+  @action stopTransferringWithoutHold = () => {
+    this.prevTransferring = this.transferring
+    this.transferring = ''
+    return pbx
+      .stopTalkerTransfer(this.pbxTenant, this.pbxTalkerId)
+      .catch(this.onStopTransferringFailure)
+  }
   @action private onStopTransferringFailure = (err: Error) => {
     this.transferring = this.prevTransferring
     this.setHolding(this.prevHolding)

--- a/src/stores/callStore2.ts
+++ b/src/stores/callStore2.ts
@@ -411,6 +411,7 @@ export class CallStore {
     this.setCurrentCallId(c.id)
     Nav().backToPageCallManage()
     await waitTimeout()
+
     if (c.holding) {
       c.toggleHoldWithCheck()
     }
@@ -529,11 +530,16 @@ export class CallStore {
         c =>
           c.id !== this.ongoingCallId &&
           c.answered &&
-          !c.transferring &&
           !c.holding &&
           !c.isAboutToHangup,
       )
-      .forEach(c => c.toggleHoldWithCheck())
+      .forEach(c => {
+        // when current call answer and bg call is transferring, it should be stop transferring and set hold.
+        if (c.transferring) {
+          c.stopTransferringWithoutHold()
+        }
+        c.toggleHoldWithCheck()
+      })
   }
   private updateBackgroundCallsDebounce = debounce(
     this.updateBackgroundCalls,

--- a/src/utils/callkeep.ts
+++ b/src/utils/callkeep.ts
@@ -154,7 +154,8 @@ export const setupCallKeepEvents = async () => {
   ) => {
     const uuid = e.callUUID.toUpperCase()
     const c = cs.calls.find(_ => _.callkeepUuid === uuid)
-    if (c && c.holding !== e.hold) {
+    // should not update hold with transferring.
+    if (c && !c.transferring && c.holding !== e.hold) {
       c.toggleHoldWithCheck()
     }
     BrekekeUtils.webrtcSetAudioEnabled(!e.hold)


### PR DESCRIPTION
Step:
1. A log in brekeke phone.
2. B call to A and answer.
=> A&B talking well.
3. A click on transfer button and click on attended transfer to C.
=> B listen music and C ringing. A hear ring back tone with transferring screen.
4. D call to A.
=> A ring with screen call from D.
5. A answer the call.
=> C disconnect.
Issue: B stop to hear music. A&B talking well. A&D talking well.
** B&D does not hear each other.