### PR TITLE
#775: Brekeke phone screen is not correct when make call in multi-calls

### DIFF
--- a/src/stores/Nav2.ts
+++ b/src/stores/Nav2.ts
@@ -145,6 +145,9 @@ export class Nav2 {
     const oc = s.getOngoingCall()
     const uuid = oc?.callkeepUuid
     if (!props?.isOutgoingCall && uuid && !oc.transferring) {
+      // With case kill app: prevDisplayingCallId not set value yet on openJavaPnOnVisible
+      // So, we should update prevDisplayingCallId when call onPageCallManage
+      s.prevDisplayingCallId = oc.id
       BrekekeUtils.onPageCallManage(uuid)
     }
     s.inPageCallManage = {


### PR DESCRIPTION
## Step
1. A log in brekeke phone and kill app.
2. B call to A and A answer.
=> A&B talking well.
=> A screen show call with B
3. A click on back button and go to keypad to call C 
=> B listen music. C ringing.
Issue: A screen is still show call with B with holding status.
Expect: A screen show call with C