### PR TITLE
#774: Brekeke phone screen is closed when end up a call in multicalls

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
@@ -387,10 +387,12 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
   }
 
   public static void tryExitClearTask() {
+
     if (!activities.isEmpty()) {
       return;
     }
-    if (!firstShowCallAppActive) {
+    // Outgoing call exist, don't move task to background
+    if (!firstShowCallAppActive && jsCallsSize == activitiesSize) {
       try {
         main.moveTaskToBack(true);
       } catch (Exception e) {


### PR DESCRIPTION
## Step
1. A log in brekeke phone and put in background.
2. B call to A and A answer.
=> A&B talking well.
3. A clic on back button and go to keypad to call C and C answer
=> B listen music.
=> A&C talking well.
4. A click on background call list and click on hang up button for call with B.
Issue: A show home phone screen.
Expect: A still in brekeke app and show call with C.
