### PR TITLE
Fix issue #805: It shows a loading screen after ending existing talking call

### DIFF
--- a/src/stores/callStore2.ts
+++ b/src/stores/callStore2.ts
@@ -273,6 +273,8 @@ export class CallStore {
         e.answerCallKeep()
         p.answeredAt = now
         BrekekeUtils.onCallConnected(e.callkeepUuid)
+        // Should be update prevDisplayingCallId when Call connected and native pageManageCall screen is showing.
+        this.prevDisplayingCallId = e.id
         BrekekeUtils.setSpeakerStatus(this.isLoudSpeakerEnabled)
       }
       Object.assign(e, p, {

--- a/src/stores/callStore2.ts
+++ b/src/stores/callStore2.ts
@@ -273,7 +273,6 @@ export class CallStore {
         e.answerCallKeep()
         p.answeredAt = now
         BrekekeUtils.onCallConnected(e.callkeepUuid)
-        // Should be update prevDisplayingCallId when Call connected and native pageManageCall screen is showing.
         this.prevDisplayingCallId = e.id
         BrekekeUtils.setSpeakerStatus(this.isLoudSpeakerEnabled)
       }


### PR DESCRIPTION
(1) Login Brekeke phone and kill it
(2) Make the 1st call to the Brekeke phone, and answer the call.
=> Call is connected and talking well
(3) On Call screen tap on Transfer button.
=> It shows the transfer screen
(4) When UC connecting message show on top, make the second call to the brekeke phone and asnwer it.
=> A screen shows loading status in about 10s, then the call is connected.
(5) End the existing talking call.
=> 
Actual: It shows a loading screen
Expected: It gets back with a remaining call and show call screen properly. 