### PR TITLE
Issue #807:  With PBX 3.12, cannot open Brekeke phone properly after getting a canceled or rejected call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 2.13.3
+
+- Fix it should use try catch while loading custom page to have backward compatibility (issue 807)
+
 #### 2.13.2
 
 - Implement call history first simple version:

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -11,6 +11,7 @@ import { BackgroundTimer } from '../utils/BackgroundTimer'
 import { BrekekeUtils } from '../utils/RnNativeModules'
 import { toBoolean } from '../utils/string'
 import { parseCallParams, parsePalParams } from './parseParamsWithPrefix'
+import { _parseListCustomPage } from './pbxCustomPage'
 import { PnCommand, PnParams, PnParamsNew, PnServiceId } from './pnConfig'
 
 export class PBX extends EventEmitter {
@@ -303,7 +304,7 @@ export class PBX extends EventEmitter {
 
     const as = getAuthStore()
     as.pbxConfig = config
-    as.parseListCustomPage()
+    _parseListCustomPage()
 
     const d = await as.getCurrentDataAsync()
     d.palParams = parsePalParams(as.pbxConfig)

--- a/src/api/pbxCustomPage.ts
+++ b/src/api/pbxCustomPage.ts
@@ -1,0 +1,89 @@
+import { random } from 'lodash'
+import validator from 'validator'
+
+import { PbxCustomPage } from '../brekekejs'
+import { getAuthStore } from '../stores/authStore'
+import { intl } from '../stores/intl'
+import { intlStore } from '../stores/intlStore'
+import { pbx } from './pbx'
+
+// TODO
+// should not use replace string in url
+// use url builder instead for safe url encoding
+
+const _buildCustomPageUrl = async (url: string) => {
+  const { token } = await pbx.getPbxToken()
+  if (!token) {
+    return url
+  }
+  const ca = getAuthStore().getCurrentAccount()
+  return url
+    .replace(/#lang#/i, intlStore.locale)
+    .replace(/#pbx-token#/i, token)
+    .replace(/#tenant#'/i, ca.pbxTenant)
+    .replace(/#user#/i, ca.pbxUsername)
+    .replace(/#from-number#/i, '0')
+}
+export const buildCustomPageUrl = (url: string) =>
+  _buildCustomPageUrl(url).catch(() => url)
+
+export const isCustomPageUrlBuilt = (url: string) => !/#pbx-token#/i.test(url)
+
+const _rebuildCustomPageUrl = async (url: string) => {
+  const { token } = await pbx.getPbxToken()
+  if (!token) {
+    return url
+  }
+  url = url.replace(/&sess=[^&]+/, `&sess=${token}`)
+  url = rebuildCustomPageUrlNonce(url)
+  return url
+}
+export const rebuildCustomPageUrl = (url: string) =>
+  _rebuildCustomPageUrl(url).catch(() => url)
+
+const _addCustomPageUrlNonce = (url: string) => {
+  // for refresh page by change from-number value
+  const hasNonce = /#from-number#/i.test(url) || /&from-number=/.test(url)
+  if (!hasNonce) {
+    return url + '&from-number=#from-number#'
+  }
+  return url
+}
+export const rebuildCustomPageUrlNonce = (url: string) =>
+  url.replace(/&from-number=([0-9]+)/, `&from-number=${random(1, 1000, false)}`)
+
+export const _parseListCustomPage = () => {
+  const as = getAuthStore()
+  const c = as.pbxConfig
+  if (!c) {
+    return
+  }
+  const results: PbxCustomPage[] = []
+  Object.keys(c).forEach(k => {
+    if (!k.startsWith('webphone.custompage')) {
+      return
+    }
+    const parts = k.split('.')
+    const id = `${parts[0]}.${parts[1]}`
+    if (results.some(item => item.id === id)) {
+      return
+    }
+    let url = c[`${id}.url`]
+    if (!validator.isURL(url)) {
+      // ignore if not url
+      return
+    }
+    url = _addCustomPageUrlNonce(url)
+    const title = c[`${id}.title`] || intl`Pbx user setting`
+    const pos = c[`${id}.pos`] || 'setting,right,1'
+    const incoming = c[`${id}.incoming`]
+    results.push({
+      id,
+      url,
+      title,
+      pos,
+      incoming,
+    })
+  })
+  as.listCustomPage = results
+}

--- a/src/api/sip.ts
+++ b/src/api/sip.ts
@@ -451,7 +451,7 @@ const getUserAgent = async (a: ParsedPn | AccountUnique) => {
     return d.userAgent
   }
   const os = osMap[Platform.OS]
-  return `Brekeke Phone for ${os} ${currentVersion} /JsSIP 3.2.15`
+  return `Brekeke Phone for ${os} ${currentVersion}, JsSIP 3.2.15`
 }
 
 const getWssUrl = (host?: string, port?: string) =>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -305,7 +305,7 @@ export const App = observer(() => {
       <View style={css.App_Inner}>
         <RnStackerRoot />
         <RenderAllCalls />
-        {cp && <PageCustomPageView id={cp?.id} />}
+        {cp && <PageCustomPageView id={cp.id} />}
         <RnPickerRoot />
         <PhonebookAddItem />
         <RnAlertRoot />

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -149,7 +149,7 @@ const File: FC<
             </RnText>
           </RnTouchableOpacity>
         )}
-        {!!p.incoming && p.state === 'waiting' && p.fileType !== 'image' && (
+        {p.incoming && p.state === 'waiting' && p.fileType !== 'image' && (
           <RnTouchableOpacity onPress={p.accept}>
             <RnText
               style={[css.Message_File_Button, css.Message_File_Accept_Button]}

--- a/src/pages/PageCustomPage.tsx
+++ b/src/pages/PageCustomPage.tsx
@@ -1,44 +1,24 @@
 import { observer } from 'mobx-react'
 import { Component } from 'react'
 
-import { pbx } from '../api/pbx'
+import { buildCustomPageUrl, isCustomPageUrlBuilt } from '../api/pbxCustomPage'
 import { getAuthStore } from '../stores/authStore'
-import { intlStore } from '../stores/intlStore'
 
 @observer
 export class PageCustomPage extends Component<{ id: string }> {
   componentDidMount = async () => {
     const { id } = this.props
-    const cp = getAuthStore().getCustomPageById(id)
+    const as = getAuthStore()
+    const cp = as.getCustomPageById(id)
     if (!cp) {
       return
     }
-    // First time open tab PageCustomPage, should update url with params
-    const tokenNotExist = /#pbx-token#/i.test(cp.url)
-    if (tokenNotExist) {
-      const url = await this.getUrlParams(cp.url)
-      getAuthStore().updateCustomPage({ ...cp, url })
-      getAuthStore().customPageLoadings[cp.id] = true
+    if (isCustomPageUrlBuilt(cp.url)) {
+      return
     }
-  }
-
-  getUrlParams = async (url: string) => {
-    // should be catch getPbxToken when get error
-    try {
-      const { token } = await pbx.getPbxToken()
-      if (!token) {
-        return url
-      }
-      const user = getAuthStore().getCurrentAccount()
-      return url
-        .replace(/#lang#/i, intlStore.locale)
-        .replace(/#pbx-token#/i, token)
-        .replace(/#tenant#'/i, user.pbxTenant)
-        .replace(/#user#/i, user.pbxUsername)
-        .replace(/#from-number#/i, '0')
-    } catch (error) {
-      return url
-    }
+    const url = await buildCustomPageUrl(cp.url)
+    as.updateCustomPage({ ...cp, url })
+    as.customPageLoadings[cp.id] = true
   }
 
   render() {

--- a/src/pages/PageCustomPage.tsx
+++ b/src/pages/PageCustomPage.tsx
@@ -23,14 +23,22 @@ export class PageCustomPage extends Component<{ id: string }> {
   }
 
   getUrlParams = async (url: string) => {
-    const token = await pbx.getPbxToken()
-    const user = getAuthStore().getCurrentAccount()
-    return url
-      .replace(/#lang#/i, intlStore.locale)
-      .replace(/#pbx-token#/i, token.token)
-      .replace(/#tenant#'/i, user.pbxTenant)
-      .replace(/#user#/i, user.pbxUsername)
-      .replace(/#from-number#/i, '0')
+    // should be catch getPbxToken when get error
+    try {
+      const { token } = await pbx.getPbxToken()
+      if (!token) {
+        return url
+      }
+      const user = getAuthStore().getCurrentAccount()
+      return url
+        .replace(/#lang#/i, intlStore.locale)
+        .replace(/#pbx-token#/i, token)
+        .replace(/#tenant#'/i, user.pbxTenant)
+        .replace(/#user#/i, user.pbxUsername)
+        .replace(/#from-number#/i, '0')
+    } catch (error) {
+      return url
+    }
   }
 
   render() {

--- a/src/pages/PageCustomPageView.tsx
+++ b/src/pages/PageCustomPageView.tsx
@@ -1,9 +1,12 @@
-import { random } from 'lodash'
 import { observer } from 'mobx-react'
 import { Component } from 'react'
 import { StyleSheet, View } from 'react-native'
 
-import { pbx } from '../api/pbx'
+import {
+  isCustomPageUrlBuilt,
+  rebuildCustomPageUrl,
+  rebuildCustomPageUrlNonce,
+} from '../api/pbxCustomPage'
 import { PbxCustomPage } from '../brekekejs'
 import { CustomPageWebView } from '../components/CustomPageWebView'
 import { Layout } from '../components/Layout'
@@ -13,7 +16,6 @@ import { v } from '../components/variables'
 import { getAuthStore } from '../stores/authStore'
 import { getCallStore } from '../stores/callStore'
 import { intl } from '../stores/intl'
-import { intlStore } from '../stores/intlStore'
 import { Nav } from '../stores/Nav'
 import { RnStacker } from '../stores/RnStacker'
 
@@ -39,106 +41,82 @@ export class PageCustomPageView extends Component<{ id: string }> {
   state = {
     isError: false,
   }
-  getUrlParams = async (url: string) => {
-    try {
-      const { token } = await pbx.getPbxToken()
-      if (!token) {
-        return url
-      }
-      const user = getAuthStore().getCurrentAccount()
-      return url
-        .replace(/#lang#/i, intlStore.locale)
-        .replace(/#pbx-token#/i, token)
-        .replace(/#tenant#'/i, user.pbxTenant)
-        .replace(/#user#/i, user.pbxUsername)
-        .replace(/#from-number#/i, '0')
-    } catch (error) {
-      return url
-    }
-  }
-  getURLToken = async (url: string) => {
-    // should be catch getPbxToken when get error
-    try {
-      const r = random(1, 1000, false).toString()
-      const { token } = await pbx.getPbxToken()
-      if (!token) {
-        return url
-      }
-      return url
-        .replace(/&sess=(.*?)&/, `&sess=${token}&`)
-        .replace(/&from-number=([0-9]+)/, `&from-number=${r}`)
-    } catch (error) {
-      return url
-    }
-  }
-  reLoadPage = async (cp: PbxCustomPage) => {
-    const tokenNotExist = /#pbx-token#/i.test(cp.url)
-    if (tokenNotExist) {
+  reloadPage = async (cp: PbxCustomPage) => {
+    if (!isCustomPageUrlBuilt(cp.url)) {
       return
     }
-    getAuthStore().reLoadCustomPageById(cp.id)
-  }
-  reloadPageWithNewToken = async () => {
-    const { id } = this.props
-    const { isError } = this.state
-    const cp = getAuthStore().getCustomPageById(id)
+    const as = getAuthStore()
+    if (as.customPageLoadings[cp.id]) {
+      return
+    }
+    as.customPageLoadings[cp.id] = true
     if (!cp) {
       return
     }
-    const url = await this.getURLToken(cp.url)
-    getAuthStore().updateCustomPage({ ...cp, url })
+    const url = rebuildCustomPageUrlNonce(cp.url)
+    as.updateCustomPage({ ...cp, url })
+  }
+  reloadPageWithNewToken = async () => {
+    const {
+      props: { id },
+      state: { isError },
+    } = this
+    const as = getAuthStore()
+    const cp = as.getCustomPageById(id)
+    if (!cp) {
+      return
+    }
+    const url = await rebuildCustomPageUrl(cp.url)
+    as.updateCustomPage({ ...cp, url })
     if (isError) {
       this.setState({ isError: false })
     }
   }
   render() {
-    const { id } = this.props
-    const { isError } = this.state
-    const au = getAuthStore()
-    const cp = au.getCustomPageById(id)
-    // Trigger get received incoming call
+    const {
+      props: { id },
+      state: { isError },
+    } = this
+    const as = getAuthStore()
+    const cp = as.getCustomPageById(id)
+    // trigger when receiving incoming call
     const c = getCallStore().calls.find(i => i.incoming && !i.answeredAt)
     const s = RnStacker.stacks[RnStacker.stacks.length - 1]
-
+    // update title to tab label
     const onTitleChanged = (t: string) => {
-      // Update title to tab label
-      if (!cp || this.state.isError || /#pbx-token#/i.test(cp.url)) {
+      if (!cp || this.state.isError || !isCustomPageUrlBuilt(cp.url)) {
         return
       }
-      au.updateCustomPage({ ...cp, title: t })
+      as.updateCustomPage({ ...cp, title: t })
     }
-
     const onLoaded = () => {
       //
     }
-
     const onError = () => {
-      if (cp && /#pbx-token#/i.test(cp.url)) {
+      if (cp && !isCustomPageUrlBuilt(cp.url)) {
         return
       }
       this.setState({ isError: true })
     }
-
     // handle open custompage tab and reload page when received incoming
     if (
-      (c || (!c && au.saveActionOpenCustomPage)) &&
+      (c || (!c && as.saveActionOpenCustomPage)) &&
       s &&
       cp &&
       cp.incoming === 'open'
     ) {
-      au.saveActionOpenCustomPage = false
+      as.saveActionOpenCustomPage = false
       if (s.name != 'PageCustomPage') {
         // update stacker flow
         Nav().customPageIndex = Nav().goToPageCustomPage
         Nav().goToPageCustomPage({ id: cp.id })
         return
       }
-      // reloadPage
-      this.reLoadPage(cp)
+      this.reloadPage(cp)
     }
     // update check loading page
     if (cp && cp.incoming === 'open' && !c) {
-      delete au.customPageLoadings[cp.id]
+      delete as.customPageLoadings[cp.id]
     }
 
     const isVisible =
@@ -173,7 +151,7 @@ export class PageCustomPageView extends Component<{ id: string }> {
               </RnText>
             </RnTouchableOpacity>
           )}
-          {cp && !/#pbx-token#/i.test(cp.url) && (
+          {cp && isCustomPageUrlBuilt(cp.url) && (
             <CustomPageWebView
               url={cp.url}
               onTitleChanged={onTitleChanged}

--- a/src/pages/PageCustomPageView.tsx
+++ b/src/pages/PageCustomPageView.tsx
@@ -40,24 +40,36 @@ export class PageCustomPageView extends Component<{ id: string }> {
     isError: false,
   }
   getUrlParams = async (url: string) => {
-    const token = await pbx.getPbxToken()
-    const user = getAuthStore().getCurrentAccount()
-    return url
-      .replace(/#lang#/i, intlStore.locale)
-      .replace(/#pbx-token#/i, token.token)
-      .replace(/#tenant#'/i, user.pbxTenant)
-      .replace(/#user#/i, user.pbxUsername)
-      .replace(/#from-number#/i, '0')
-  }
-  getURLToken = async (url: string) => {
-    const r = random(1, 1000, false).toString()
-    const { token } = await pbx.getPbxToken()
-    if (!token) {
+    try {
+      const { token } = await pbx.getPbxToken()
+      if (!token) {
+        return url
+      }
+      const user = getAuthStore().getCurrentAccount()
+      return url
+        .replace(/#lang#/i, intlStore.locale)
+        .replace(/#pbx-token#/i, token)
+        .replace(/#tenant#'/i, user.pbxTenant)
+        .replace(/#user#/i, user.pbxUsername)
+        .replace(/#from-number#/i, '0')
+    } catch (error) {
       return url
     }
-    return url
-      .replace(/&sess=(.*?)&/, `&sess=${token}&`)
-      .replace(/&from-number=([0-9]+)/, `&from-number=${r}`)
+  }
+  getURLToken = async (url: string) => {
+    // should be catch getPbxToken when get error
+    try {
+      const r = random(1, 1000, false).toString()
+      const { token } = await pbx.getPbxToken()
+      if (!token) {
+        return url
+      }
+      return url
+        .replace(/&sess=(.*?)&/, `&sess=${token}&`)
+        .replace(/&from-number=([0-9]+)/, `&from-number=${r}`)
+    } catch (error) {
+      return url
+    }
   }
   reLoadPage = async (cp: PbxCustomPage) => {
     const tokenNotExist = /#pbx-token#/i.test(cp.url)

--- a/src/pages/PageCustomPageView.tsx
+++ b/src/pages/PageCustomPageView.tsx
@@ -151,7 +151,7 @@ export class PageCustomPageView extends Component<{ id: string }> {
               </RnText>
             </RnTouchableOpacity>
           )}
-          {cp && isCustomPageUrlBuilt(cp.url) && (
+          {!!cp?.url && isCustomPageUrlBuilt(cp.url) && (
             <CustomPageWebView
               url={cp.url}
               onTitleChanged={onTitleChanged}


### PR DESCRIPTION
(1). A logs in brekeke phone then kill app
(2). B logs in webphone and calls A
(3). B hangs up to cancel the call > A's call screen disappears
(4). A opens brekeke phone app again
Issue: Brekeke phone app can not loaded, it shows white screen.
Expect: Brekeke phone is loaded well
 *** If reject or call no answer or answer call at step3, it also occurs.