### PR TITLE
#814: Should be check UUID before call native answerIncomingCall function

### DIFF
--- a/src/stores/Call.ts
+++ b/src/stores/Call.ts
@@ -82,16 +82,18 @@ export class Call {
   }
   answerCallKeep = async () => {
     this.store.setCurrentCallId(this.id)
+    // this wait timeout was added intentionally to prevent interacting with callkeep too quick
+    // but not sure if it actually improves any?
     await waitTimeout()
     if (!this.callkeepUuid) {
       return
     }
+    this.callkeepAlreadyAnswered = true
     if (this.incoming) {
       RNCallKeep.answerIncomingCall(this.callkeepUuid)
     } else {
       RNCallKeep.reportConnectedOutgoingCallWithUUID(this.callkeepUuid)
     }
-    this.callkeepAlreadyAnswered = true
     RNCallKeep.setCurrentCallActive(this.callkeepUuid)
     RNCallKeep.setOnHold(this.callkeepUuid, false)
     BrekekeUtils.setOnHold(this.callkeepUuid, false)

--- a/src/stores/Call.ts
+++ b/src/stores/Call.ts
@@ -82,16 +82,16 @@ export class Call {
   }
   answerCallKeep = async () => {
     this.store.setCurrentCallId(this.id)
+    await waitTimeout()
     if (!this.callkeepUuid) {
       return
     }
-    this.callkeepAlreadyAnswered = true
-    await waitTimeout()
     if (this.incoming) {
       RNCallKeep.answerIncomingCall(this.callkeepUuid)
     } else {
       RNCallKeep.reportConnectedOutgoingCallWithUUID(this.callkeepUuid)
     }
+    this.callkeepAlreadyAnswered = true
     RNCallKeep.setCurrentCallActive(this.callkeepUuid)
     RNCallKeep.setOnHold(this.callkeepUuid, false)
     BrekekeUtils.setOnHold(this.callkeepUuid, false)

--- a/src/stores/callStore2.ts
+++ b/src/stores/callStore2.ts
@@ -59,28 +59,24 @@ export class CallStore {
     )
   }
 
-  private autoAnswer = (uuid: string) => {
-    if (!uuid) {
-      return
-    }
-    if (Platform.OS === 'ios') {
-      RNCallKeep.answerIncomingCall(uuid)
-    }
-    BrekekeUtils.onCallKeepAction(uuid, 'answerCall')
-  }
   @action onCallKeepDidDisplayIncomingCall = async (
     uuid: string,
     n?: ParsedPn,
   ) => {
     this.setAutoEndCallKeepTimer(uuid, n)
-    if (!n) {
+    if (!uuid || !n) {
       return
     }
     if (n.sipPn.autoAnswer && !this.calls.some(c => c.callkeepUuid !== uuid)) {
       if (RnAppState.foregroundOnce && AppState.currentState !== 'active') {
         RNCallKeep.backToForeground()
       }
-      BackgroundTimer.setTimeout(() => this.autoAnswer(uuid), 2000)
+      BackgroundTimer.setTimeout(() => {
+        if (Platform.OS === 'ios') {
+          RNCallKeep.answerIncomingCall(uuid)
+        }
+        BrekekeUtils.onCallKeepAction(uuid, 'answerCall')
+      }, 2000)
     }
     checkAndRemovePnTokenViaSip(n)
     // find the current incoming call which is not callkeep

--- a/src/stores/callStore2.ts
+++ b/src/stores/callStore2.ts
@@ -60,6 +60,9 @@ export class CallStore {
   }
 
   private autoAnswer = (uuid: string) => {
+    if (!uuid) {
+      return
+    }
     if (Platform.OS === 'ios') {
       RNCallKeep.answerIncomingCall(uuid)
     }


### PR DESCRIPTION
1.2 - Reproduced:
Settings: Create ringing group ext 12001 that has "Group extensions": 101, 102
Steps:
(1) Login Brekeke phone with 101, and login UC 102 ( can be webphone or brekeke phone)
(2) Caller calls to 12001
=> 101 and 102 receive the call simultaneouly.
(3) Both 101 and 102 tries to answer the call at same time. But 102 is quicker and connects to the call.
'=> An error message appears on Brekeke phone (101), After 3 seconds it disappear then switches to Phone's home screen.

1.3 - Found new case
(1) User A (Brekeke phone) makes an outgoing call, and user B (can be any application) also calls to the brekeke phone at the same time
=> It shows Call screen on Brekeke phone with 2 options: "Decline" and "End&Accept"
(2) User B hang up and User A selects "End&Accept" simultaneously.
=> An error message appears on Brekeke phone, After 3 seconds it disappear then switches to Phone's home screen.