### PR TITLE
Issue 815: The call auto callback and has no voice ( nurse call #3 )

### DIFF
--- a/src/stores/callStore2.ts
+++ b/src/stores/callStore2.ts
@@ -520,7 +520,12 @@ export class CallStore {
         // it's likely a connection issue occurred
         if (!curr && !reconnectCalled && diff > 3000) {
           reconnectCalled = true
-          reconnectAndWaitSip().then(sipCreateSession)
+          reconnectAndWaitSip().then(() => {
+            if (!this.startCallIntervalId) {
+              return
+            }
+            sipCreateSession()
+          })
           this.clearStartCallIntervalTimer()
         }
       }),


### PR DESCRIPTION
Steps:
(1) Brekeke phone make calls to external number and quickly cancels the call
=> The call screen is clear on Brekeke phone.
But after after that it shows a call bar that call to the external user on top screen.
If Callee answers, the call has no voice.

***Note:
- The issue also occur when making internal call.
- The issue only occur with iOS 

Video: https://drive.google.com/file/d/1UaktYrCDV7RifFehXDGok2onnzH2UI8q/view?usp=sharing