### PR TITLE
Linking with phoneappli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Fix it should load recent chats when open the app by tapping on a notification (issue 827)
   - Improve it should not log in if PN is received without user tapping
   - Improve it should navigate to screen chat detail instead of screen chat recents when user tapping on a UC chat notification
+- Implement PhoneAppli linking
 
 #### 2.13.7
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -130,7 +130,8 @@
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
-        <data android:scheme="brekekeapp_phonedev" android:host="open" />
+        <data android:scheme="brekekeappphonedev" android:host="open" />
+        <data android:scheme="brekekeappphonedev" android:host="makecall" />
       </intent-filter>
     </activity>
     <!-- call history -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -142,8 +142,8 @@
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
-        <data android:scheme="brekekeappphonedev" android:host="open" />
-        <data android:scheme="brekekephonedev" android:host="makecall" />
+        <data android:scheme="brekekephonedev" android:host="open" />
+        <data android:scheme="brekekephonedev" android:host="call" />
       </intent-filter>
     </activity>
     <!-- default phone call app -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -131,7 +131,6 @@
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="brekekeappphonedev" android:host="open" />
-        <data android:scheme="brekekeappphonedev" android:host="makecall" />
         <data android:scheme="brekekephonedev" android:host="makecall" />
       </intent-filter>
     </activity>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -132,6 +132,7 @@
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="brekekeappphonedev" android:host="open" />
         <data android:scheme="brekekeappphonedev" android:host="makecall" />
+        <data android:scheme="brekekephonedev" android:host="makecall" />
       </intent-filter>
     </activity>
     <!-- call history -->

--- a/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
@@ -100,6 +100,7 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
   public static boolean isAppActive = false;
   public static boolean isAppActiveLocked = false;
   public static boolean firstShowCallAppActive = false;
+  public static boolean phoneappliEnabled = false;
 
   BrekekeUtils(ReactApplicationContext c) {
     super(c);
@@ -623,6 +624,10 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
 
   // ==========================================================================
   // react methods
+  @ReactMethod
+  public void setPhoneappliEnabled(Boolean isEnabled) {
+    BrekekeUtils.phoneappliEnabled = isEnabled;
+  }
 
   @ReactMethod
   public void insertCallLog(String number, int type) {

--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -626,7 +626,7 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
 
   public void handleShowAvatarTalking() {
     destroyAvatarWebView();
-    if (BrekekeUtils.isImageUrl(talkingAvatar)) {
+    if (BrekekeUtils.phoneappliEnabled || BrekekeUtils.isImageUrl(talkingAvatar)) {
       webViewAvatarTalking.setVisibility(View.GONE);
       imgAvatarTalking.setVisibility(View.VISIBLE);
       Glide.with(this)
@@ -1015,6 +1015,7 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
   public void setImageTalkingUrl(String url, boolean _isLarge) {
     talkingAvatar = url;
     isLarge = _isLarge;
+    handleShowAvatarTalking();
   }
 
   public void setRecordingStatus(boolean isRecording) {

--- a/ios/BrekekePhone/Info.plist
+++ b/ios/BrekekePhone/Info.plist
@@ -31,7 +31,6 @@
       <dict>
         <key>CFBundleURLSchemes</key>
         <array>
-          <string>brekekeappphonedev</string>
           <string>brekekephonedev</string>
         </array>
       </dict>

--- a/ios/BrekekePhone/Info.plist
+++ b/ios/BrekekePhone/Info.plist
@@ -31,7 +31,7 @@
       <dict>
         <key>CFBundleURLSchemes</key>
         <array>
-          <string>brekekeapp_phonedev</string>
+          <string>brekekeappphonedev</string>
         </array>
       </dict>
     </array>

--- a/ios/BrekekePhone/Info.plist
+++ b/ios/BrekekePhone/Info.plist
@@ -32,6 +32,7 @@
         <key>CFBundleURLSchemes</key>
         <array>
           <string>brekekeappphonedev</string>
+          <string>brekekephonedev</string>
         </array>
       </dict>
     </array>

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -384,6 +384,7 @@ export class PBX extends EventEmitter {
         'p4_ptype',
         'pnumber',
         'language',
+        'phoneappli.enable',
       ],
     })
 
@@ -416,6 +417,7 @@ export class PBX extends EventEmitter {
       name: userName,
       phones,
       language: lang,
+      phoneappli: toBoolean(res?.[7]),
     }
   }
 

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -458,6 +458,24 @@ export class PBX extends EventEmitter {
     const res = await this.client.call_pal('getPhonebooks')
     return res?.filter(item => !item.shared) || []
   }
+  getPhoneappliContact = async (tenant: string, user: string, tel: string) => {
+    if (this.isMainInstance) {
+      await waitPbx()
+    }
+    if (!this.client) {
+      return
+    }
+    try {
+      const res = await this.client.call_pal('getPhoneAppliContact', {
+        tenant,
+        user,
+        tel,
+      })
+      return res
+    } catch (error) {
+      return {}
+    }
+  }
   getContact = async (id: string) => {
     if (this.isMainInstance) {
       await waitPbx()

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -480,7 +480,7 @@ export class PBX extends EventEmitter {
         tel,
       })
       return res
-    } catch (error) {
+    } catch (err) {
       return {}
     }
   }

--- a/src/api/updatePhoneIndex.ts
+++ b/src/api/updatePhoneIndex.ts
@@ -1,4 +1,3 @@
-import { accountStore } from '../stores/accountStore'
 import { getAuthStore } from '../stores/authStore'
 import { intl, intlDebug } from '../stores/intl'
 import { Nav } from '../stores/Nav'
@@ -27,11 +26,9 @@ export const updatePhoneIndex = async (
   }
 
   // upsert account info with properties phoneappli.enable
-  if (p === getAuthStore().getCurrentAccount()) {
-    accountStore.upsertAccount({
-      id: p.id,
-      phoneappliEnabled: extProps.phoneappli,
-    })
+  const as = getAuthStore()
+  if (p.id === as.getCurrentAccount().id) {
+    as.userExtensionProperties = extProps
   }
 
   const phone = extProps.phones[phoneIndex - 1]

--- a/src/api/updatePhoneIndex.ts
+++ b/src/api/updatePhoneIndex.ts
@@ -27,10 +27,12 @@ export const updatePhoneIndex = async (
   }
 
   // upsert account info with properties phoneappli.enable
-  accountStore.upsertAccount({
-    id: p.id,
-    phoneappliEnabled: extProps.phoneappli,
-  })
+  if (p === getAuthStore().getCurrentAccount()) {
+    accountStore.upsertAccount({
+      id: p.id,
+      phoneappliEnabled: extProps.phoneappli,
+    })
+  }
 
   const phone = extProps.phones[phoneIndex - 1]
   const phoneTypeCorrect = phone.type === 'Web Phone'

--- a/src/api/updatePhoneIndex.ts
+++ b/src/api/updatePhoneIndex.ts
@@ -1,3 +1,4 @@
+import { accountStore } from '../stores/accountStore'
 import { getAuthStore } from '../stores/authStore'
 import { intl, intlDebug } from '../stores/intl'
 import { Nav } from '../stores/Nav'
@@ -24,12 +25,18 @@ export const updatePhoneIndex = async (
     console.error('updatePhoneIndex.setExtensionProperties: extProps undefined')
     return null
   }
+
+  // upsert account info with properties phoneappli.enable
+  accountStore.upsertAccount({
+    id: p.id,
+    phoneappliEnabled: extProps.phoneappli,
+  })
+
   const phone = extProps.phones[phoneIndex - 1]
   const phoneTypeCorrect = phone.type === 'Web Phone'
   const { pbxTenant, pbxUsername } = p
   const expectedPhoneId = `${pbxTenant}_${pbxUsername}_phone${phoneIndex}_webphone`
   const phoneIdCorrect = phone.id === expectedPhoneId
-  //
   const setExtensionProperties = async () => {
     if (!api.client) {
       console.error(
@@ -37,6 +44,7 @@ export const updatePhoneIndex = async (
       )
       return
     }
+
     await api.client.call_pal('setExtensionProperties', {
       tenant: pbxTenant,
       extension: pbxUsername,
@@ -46,11 +54,12 @@ export const updatePhoneIndex = async (
         [`p${phoneIndex}_ptype`]: phone.type,
       },
     })
+
     if (p === getAuthStore().getCurrentAccount()) {
       getAuthStore().userExtensionProperties = extProps
     }
   }
-  //
+
   if (phoneTypeCorrect && phoneIdCorrect) {
     // do nothing
   } else if (phoneTypeCorrect && !phoneIdCorrect) {

--- a/src/brekekejs/index.d.ts
+++ b/src/brekekejs/index.d.ts
@@ -171,13 +171,11 @@ export type PbxPal = {
     resolve: (res: PbxContact) => void,
     reject: ErrorHandler,
   ): void
-
   getPhoneAppliContact(
     p: PbxGetPhoneappliContactParam,
     resolve: (res: PbxPhoneappliContact) => void,
     reject: ErrorHandler,
   ): void
-
   setContact(
     p: PbxContact,
     resolve: (res: PbxContact) => void,

--- a/src/brekekejs/index.d.ts
+++ b/src/brekekejs/index.d.ts
@@ -171,6 +171,13 @@ export type PbxPal = {
     resolve: (res: PbxContact) => void,
     reject: ErrorHandler,
   ): void
+
+  getPhoneAppliContact(
+    p: PbxGetPhoneappliContactParam,
+    resolve: (res: PbxPhoneappliContact) => void,
+    reject: ErrorHandler,
+  ): void
+
   setContact(
     p: PbxContact,
     resolve: (res: PbxContact) => void,
@@ -272,6 +279,11 @@ export type PbxGetContactListItem = {
   user?: string
 }
 
+export type PbxGetPhoneappliContactParam = {
+  tenant: string
+  user: string
+  tel: string
+}
 export type PbxGetContactParam = {
   aid: string
 }
@@ -314,6 +326,10 @@ export type PbxParkParam = {
 export type PbxBook = {
   phonebook: string
   shared?: string
+}
+export type PbxPhoneappliContact = {
+  display_name?: string
+  image_url?: string
 }
 export type PbxContact = {
   aid: string

--- a/src/brekekejs/pal.js
+++ b/src/brekekejs/pal.js
@@ -93,6 +93,7 @@ Brekeke.pbx.getPalPrototype = function () {
     'getPhonebooks',
     'getContactList',
     'getContact',
+    'getPhoneAppliContact',
     'setContact',
     'getPnApplicationInfo',
     'createSessionToken',

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -106,15 +106,15 @@ const initApp = async () => {
     s.resetFailureState()
     cs.onCallKeepAction()
     pnToken.syncForAllAccounts()
-    const h = await s.handleUrlParams()
+    if (checkHasCallOrWakeFromPN() || (await s.handleUrlParams())) {
+      return
+    }
     // with ios when wakekup app, currentState will be 'unknown' first then 'active'
     // https://github.com/facebook/react-native-website/issues/273
     if (Platform.OS !== 'ios') {
       return
     }
-    if (!checkHasCallOrWakeFromPN() && !h) {
-      await autoLogin()
-    }
+    await autoLogin()
   })
 
   NetInfo.addEventListener(({ isConnected }) => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -106,12 +106,13 @@ const initApp = async () => {
     s.resetFailureState()
     cs.onCallKeepAction()
     pnToken.syncForAllAccounts()
+    const h = await s.handleUrlParams()
     // with ios when wakekup app, currentState will be 'unknown' first then 'active'
     // https://github.com/facebook/react-native-website/issues/273
     if (Platform.OS !== 'ios') {
       return
     }
-    if (!checkHasCallOrWakeFromPN() && !(await s.handleUrlParams())) {
+    if (!checkHasCallOrWakeFromPN() && !h) {
       await autoLogin()
     }
   })
@@ -167,7 +168,6 @@ const initApp = async () => {
   }, 17)
   const clearReaction = reaction(() => s.signedInId, onAuthUpdate)
   void clearReaction
-
   if (await s.handleUrlParams()) {
     console.log('App navigated by url params')
     // already navigated

--- a/src/components/App.web.tsx
+++ b/src/components/App.web.tsx
@@ -96,8 +96,8 @@ export const App = () => {
     const params = parse(window.location as any as Url<any>)
     const q = qs.stringify(params)
     const appUrl = isIOS
-      ? `brekekeapp_phonedev://open?${q}`
-      : `intent://open?${q}#Intent;scheme=brekekeapp_phonedev;package=${bundleIdentifier};end`
+      ? `brekekephonedev://open?${q}`
+      : `intent://open?${q}#Intent;scheme=brekekephonedev;package=${bundleIdentifier};end`
     child = (
       <>
         <RnImage

--- a/src/components/navigationConfig.ts
+++ b/src/components/navigationConfig.ts
@@ -138,15 +138,15 @@ const genMenus = (customPages: PbxCustomPage[]) => {
     m.defaultSubMenu = m.subMenusMap?.[m.defaultSubMenuKey]
     m.subMenus.forEach(s => {
       s.navFn = () => {
-        const authStore = getAuthStore()
-        const currentAccount = authStore.getCurrentAccount()
-        if (s.ucRequired && !currentAccount?.ucEnabled) {
+        const as = getAuthStore()
+        const ca = as.getCurrentAccount()
+        if (s.ucRequired && !ca?.ucEnabled) {
           m.defaultSubMenu.navFn()
           return
         }
 
         // handle link to phoneappli app
-        if (authStore.phoneappliEnabled()) {
+        if (as.phoneappliEnabled()) {
           if (s.navFnKey === 'goToPageContactPhonebook') {
             openLinkSafely(URLSchemes.phoneappli.USERS)
             return

--- a/src/components/navigationConfig.ts
+++ b/src/components/navigationConfig.ts
@@ -114,6 +114,11 @@ const genMenus = (customPages: PbxCustomPage[]) => {
           label: intl`PARKS`,
           navFnKey: 'goToPageCallParks',
         },
+        {
+          key: 'voicemail',
+          label: intl`VOICEMAIL`,
+          navFnKey: 'goToPageVoicemail',
+        },
       ],
       defaultSubMenuKey: getAuthStore().phoneappliEnabled()
         ? 'keypad'
@@ -143,13 +148,17 @@ const genMenus = (customPages: PbxCustomPage[]) => {
           m.defaultSubMenu.navFn()
           return
         }
+
         // handle link to phoneappli app
         if (authStore.phoneappliEnabled()) {
           if (s.navFnKey === 'goToPageContactPhonebook') {
             Linking.openURL(URLSchemes.phoneappli.USERS)
             return
           }
-          if (s.navFnKey === 'goToPageCallRecents') {
+          if (
+            s.navFnKey === 'goToPageCallRecents' ||
+            s.navFnKey === 'backToPageCallRecents'
+          ) {
             Linking.openURL(URLSchemes.phoneappli.HISTORY_CALLED)
             return
           }

--- a/src/components/navigationConfig.ts
+++ b/src/components/navigationConfig.ts
@@ -1,5 +1,3 @@
-import { Linking } from 'react-native'
-
 import {
   mdiAccountCircleOutline,
   mdiCogOutline,
@@ -13,7 +11,7 @@ import { intlStore } from '../stores/intlStore'
 import { Nav } from '../stores/Nav'
 import { RnAlert } from '../stores/RnAlert'
 import { arrToMap } from '../utils/arrToMap'
-import { URLSchemes } from '../utils/deeplink'
+import { openLinkSafely, URLSchemes } from '../utils/deeplink'
 
 export type Menu = {
   key: string
@@ -150,14 +148,14 @@ const genMenus = (customPages: PbxCustomPage[]) => {
         // handle link to phoneappli app
         if (authStore.phoneappliEnabled()) {
           if (s.navFnKey === 'goToPageContactPhonebook') {
-            Linking.openURL(URLSchemes.phoneappli.USERS)
+            openLinkSafely(URLSchemes.phoneappli.USERS)
             return
           }
           if (
             s.navFnKey === 'goToPageCallRecents' ||
             s.navFnKey === 'backToPageCallRecents'
           ) {
-            Linking.openURL(URLSchemes.phoneappli.HISTORY_CALLED)
+            openLinkSafely(URLSchemes.phoneappli.HISTORY_CALLED)
             return
           }
         }

--- a/src/components/navigationConfig.ts
+++ b/src/components/navigationConfig.ts
@@ -120,9 +120,7 @@ const genMenus = (customPages: PbxCustomPage[]) => {
           navFnKey: 'goToPageVoicemail',
         },
       ],
-      defaultSubMenuKey: getAuthStore().phoneappliEnabled()
-        ? 'keypad'
-        : 'recents',
+      defaultSubMenuKey: 'keypad',
     },
     {
       key: 'settings',

--- a/src/components/navigationConfig2.ts
+++ b/src/components/navigationConfig2.ts
@@ -36,7 +36,7 @@ export const getTabs = (tab: string) => {
     subMenus.push({
       key: 'phonebook',
       label: intl`PHONEBOOK`,
-      navFnKey: (() => {}) as any,
+      navFnKey: {} as any,
     })
   }
 
@@ -58,12 +58,11 @@ export const getTabs = (tab: string) => {
       (s: SubMenu) => s,
     ) as Menu['subMenusMap']
     m.defaultSubMenu = m.subMenusMap?.[m.defaultSubMenuKey]
-
     m.subMenus.forEach(s => {
       s.navFn = action(() => {
         const name = Object.keys(s.navFnKey)[0]
         // handle link to phoneappli app
-        if (s.key === 'phonebook') {
+        if (!name || s.key === 'phonebook') {
           openLinkSafely(URLSchemes.phoneappli.USERS)
           return
         }

--- a/src/components/navigationConfig2.ts
+++ b/src/components/navigationConfig2.ts
@@ -1,10 +1,13 @@
 import { action } from 'mobx'
 import { ReactComponentLike } from 'prop-types'
+import { Linking } from 'react-native'
 
+import { getAuthStore } from '../stores/authStore'
 import { intl } from '../stores/intl'
 import { RnAlert } from '../stores/RnAlert'
 import { RnStacker } from '../stores/RnStacker'
 import { arrToMap } from '../utils/arrToMap'
+import { URLSchemes } from '../utils/deeplink'
 import { Menu, SubMenu } from './navigationConfig'
 
 let PageCallTransferChooseUser: ReactComponentLike
@@ -17,22 +20,32 @@ export const setPageCallTransferDial = (p: ReactComponentLike) => {
 }
 
 export const getTabs = (tab: string) => {
+  const subMenus = [
+    {
+      key: 'list_user',
+      label: intl`USER`,
+      navFnKey: { PageCallTransferChooseUser },
+    },
+    {
+      key: 'external_number',
+      label: intl`KEYPAD`,
+      navFnKey: { PageCallTransferDial },
+    },
+  ]
+  // add phonebook tab if phoneappli is enabled
+  if (getAuthStore().phoneappliEnabled()) {
+    subMenus.push({
+      key: 'phonebook',
+      label: intl`PHONEBOOK`,
+      navFnKey: (() => {}) as any,
+    })
+  }
+
   const arr = [
     {
       key: 'call_transfer',
       icon: null,
-      subMenus: [
-        {
-          key: 'list_user',
-          label: intl`USER`,
-          navFnKey: { PageCallTransferChooseUser },
-        },
-        {
-          key: 'external_number',
-          label: intl`KEYPAD`,
-          navFnKey: { PageCallTransferDial },
-        },
-      ],
+      subMenus,
       defaultSubMenuKey: 'list_user',
     },
   ] as any as Menu[]
@@ -46,9 +59,15 @@ export const getTabs = (tab: string) => {
       (s: SubMenu) => s,
     ) as Menu['subMenusMap']
     m.defaultSubMenu = m.subMenusMap?.[m.defaultSubMenuKey]
+
     m.subMenus.forEach(s => {
       s.navFn = action(() => {
         const name = Object.keys(s.navFnKey)[0]
+        // handle link to phoneappli app
+        if (s.key === 'phonebook') {
+          Linking.openURL(URLSchemes.phoneappli.USERS)
+          return
+        }
         // @ts-ignore
         const Component: ReactComponentLike = s.navFnKey[name]
         const lastStack = RnStacker.stacks.pop()

--- a/src/components/navigationConfig2.ts
+++ b/src/components/navigationConfig2.ts
@@ -1,13 +1,12 @@
 import { action } from 'mobx'
 import { ReactComponentLike } from 'prop-types'
-import { Linking } from 'react-native'
 
 import { getAuthStore } from '../stores/authStore'
 import { intl } from '../stores/intl'
 import { RnAlert } from '../stores/RnAlert'
 import { RnStacker } from '../stores/RnStacker'
 import { arrToMap } from '../utils/arrToMap'
-import { URLSchemes } from '../utils/deeplink'
+import { openLinkSafely, URLSchemes } from '../utils/deeplink'
 import { Menu, SubMenu } from './navigationConfig'
 
 let PageCallTransferChooseUser: ReactComponentLike
@@ -65,7 +64,7 @@ export const getTabs = (tab: string) => {
         const name = Object.keys(s.navFnKey)[0]
         // handle link to phoneappli app
         if (s.key === 'phonebook') {
-          Linking.openURL(URLSchemes.phoneappli.USERS)
+          openLinkSafely(URLSchemes.phoneappli.USERS)
           return
         }
         // @ts-ignore

--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -200,6 +200,11 @@ const css = StyleSheet.create({
     alignItems: 'center',
   },
 })
+export const backAction = () => {
+  return getAuthStore().phoneappliEnabled()
+    ? Nav().backToPageCallKeypad()
+    : Nav().backToPageCallRecents()
+}
 
 // render all the calls in App.tsx
 // the avatars will be kept even if we navigate between views
@@ -210,13 +215,13 @@ export class RenderAllCalls extends Component {
   componentDidMount() {
     const s = getCallStore()
     if (s.inPageCallManage && !s.calls.length) {
-      Nav().backToPageCallRecents()
+      backAction()
     }
   }
   componentDidUpdate() {
     const l = getCallStore().calls.length
     if (this.prevCallsLength && !l) {
-      Nav().backToPageCallRecents()
+      backAction()
     }
     this.prevCallsLength = l
   }
@@ -228,7 +233,7 @@ export class RenderAllCalls extends Component {
         <Layout
           compact
           noScroll
-          onBack={Nav().backToPageCallRecents}
+          onBack={backAction}
           title={intl`Connecting...`}
         />
       )
@@ -388,7 +393,7 @@ class PageCallManage extends Component<{
             : undefined
         }
         noScroll
-        onBack={Nav().backToPageCallRecents}
+        onBack={backAction}
         title={c.getDisplayName() || intl`Connecting...`}
         transparent={!c.transferring}
       >

--- a/src/pages/PageCallRecents.tsx
+++ b/src/pages/PageCallRecents.tsx
@@ -85,16 +85,6 @@ export class PageCallRecents extends Component {
           }}
           value={contactStore.callSearchRecents}
         />
-        <Field
-          isGroup
-          label={intl`VOICEMAIL (${getCallStore().newVoicemailCount})`}
-        />
-        <UserItem
-          iconFuncs={[() => getCallStore().startCall('8')]}
-          icons={[mdiPhone]}
-          name={intl`Voicemail`}
-          isVoicemail
-        />
         <Field isGroup label={intl`RECENT CALLS (${calls.length})`} />
         {calls.map((c, i) => (
           <UserItem

--- a/src/pages/PageCallTransferAttend.tsx
+++ b/src/pages/PageCallTransferAttend.tsx
@@ -125,7 +125,7 @@ export class PageCallTransferAttend extends Component {
         username: rt?.display_name,
       }
       this.setState({ phoneappliSource, phoneappliTarget })
-    } catch (error) {
+    } catch (err) {
       return
     }
   }

--- a/src/pages/PageVoicemail.tsx
+++ b/src/pages/PageVoicemail.tsx
@@ -1,0 +1,34 @@
+import { observer } from 'mobx-react'
+import { Component } from 'react'
+
+import { mdiPhone } from '../assets/icons'
+import { UserItem } from '../components/ContactUserItem'
+import { Field } from '../components/Field'
+import { Layout } from '../components/Layout'
+import { getCallStore } from '../stores/callStore'
+import { intl } from '../stores/intl'
+
+@observer
+export class PageVoicemail extends Component {
+  render() {
+    return (
+      <Layout
+        description={intl`Voicemail`}
+        menu='call'
+        subMenu='voicemail'
+        title={intl`VOICEMAIL`}
+      >
+        <Field
+          isGroup
+          label={intl`VOICEMAIL (${getCallStore().newVoicemailCount})`}
+        />
+        <UserItem
+          iconFuncs={[() => getCallStore().startCall('8')]}
+          icons={[mdiPhone]}
+          name={intl`Voicemail`}
+          isVoicemail
+        />
+      </Layout>
+    )
+  }
+}

--- a/src/stores/Call.ts
+++ b/src/stores/Call.ts
@@ -28,7 +28,6 @@ export class Call {
   @observable partyImageUrl = ''
   @observable partyImageSize = ''
   @observable talkingImageUrl = ''
-  /** @deprecated use below getDisplayName instead */
   @observable partyName = ''
   @observable pbxTenant = ''
   @observable pbxRoomId = ''
@@ -36,10 +35,11 @@ export class Call {
   @observable pbxUsername = ''
   @observable isFrontCamera = true
   @observable callConfig: CallConfig = {}
-
+  phoneappliUsername = ''
+  phoneappliAvatar = ''
   getDisplayName = () =>
-    getPartyName(this.partyNumber) ||
     this.partyName ||
+    getPartyName(this.partyNumber) ||
     this.partyNumber ||
     this.pbxTalkerId ||
     this.id

--- a/src/stores/Nav2.ts
+++ b/src/stores/Nav2.ts
@@ -29,6 +29,7 @@ import { PagePhonebookUpdate } from '../pages/PagePhonebookUpdate'
 import { PageSettingsCurrentAccount } from '../pages/PageSettingsCurrentAccount'
 import { PageSettingsDebug } from '../pages/PageSettingsDebug'
 import { PageSettingsOther } from '../pages/PageSettingsOther'
+import { PageVoicemail } from '../pages/PageVoicemail'
 import { PageWebChat } from '../pages/PageWebChat'
 import { BrekekeUtils } from '../utils/RnNativeModules'
 import { getAuthStore } from './authStore'
@@ -87,6 +88,15 @@ export class Nav2 {
   backToPageCallRecents = RnStacker.createBackTo<
     ComponentProps<typeof PageCallRecents>
   >({ PageCallRecents }, true)
+
+  goToPageVoicemail = RnStacker.createGoTo<
+    ComponentProps<typeof PageVoicemail>
+  >({ PageVoicemail }, true)
+
+  backToPageVoicemail = RnStacker.createBackTo<
+    ComponentProps<typeof PageVoicemail>
+  >({ PageVoicemail }, true)
+
   goToPageCallParks = RnStacker.createGoTo<
     ComponentProps<typeof PageCallParks>
   >({ PageCallParks }, true)

--- a/src/stores/accountStore.ts
+++ b/src/stores/accountStore.ts
@@ -39,6 +39,7 @@ export type Account = {
   displayOfflineUsers?: boolean
   navIndex: number
   navSubMenus: string[]
+  phoneappliEnabled?: boolean
 }
 export type AccountData = {
   id: string

--- a/src/stores/accountStore.ts
+++ b/src/stores/accountStore.ts
@@ -39,7 +39,6 @@ export type Account = {
   displayOfflineUsers?: boolean
   navIndex: number
   navSubMenus: string[]
-  phoneappliEnabled?: boolean
 }
 export type AccountData = {
   id: string

--- a/src/stores/authStore2.ts
+++ b/src/stores/authStore2.ts
@@ -331,7 +331,7 @@ export class AuthStore {
       }
 
       // checking phoneappli is enabled
-      if (!auth.getCurrentAccount().phoneappliEnabled) {
+      if (!auth.phoneappliEnabled()) {
         cleanUpUrlParams()
         return true
       }

--- a/src/stores/authStore2.ts
+++ b/src/stores/authStore2.ts
@@ -326,10 +326,12 @@ export class AuthStore {
         })
         // checking user is current user or not
         if (!(this.signedInId && this.signedInId === ac?.id)) {
-          this.signOut()
+          if (this.signedInId) {
+            this.signOut()
+          }
           const signed = ac
             ? await this.signIn(ac, true)
-            : await auth.autoSignInLast()
+            : await auth.autoSignInFistAccount()
           if (!signed) {
             cleanUpUrlParams()
             return true

--- a/src/stores/authStore2.ts
+++ b/src/stores/authStore2.ts
@@ -13,6 +13,7 @@ import {
 import { BackgroundTimer } from '../utils/BackgroundTimer'
 import { clearUrlParams, getUrlParams } from '../utils/deeplink'
 import { ParsedPn, SipPn } from '../utils/PushNotification-parse'
+import { BrekekeUtils } from '../utils/RnNativeModules'
 import { waitTimeout } from '../utils/waitTimeout'
 import {
   Account,
@@ -161,6 +162,7 @@ export class AuthStore {
       return true
     }
     this.signedInId = a.id
+    BrekekeUtils.setPhoneappliEnabled(!!this.phoneappliEnabled())
     if (!autoSignIn) {
       await saveLastSignedInId(getAccountUniqueId(a))
     }
@@ -306,7 +308,7 @@ export class AuthStore {
       this.alreadyHandleDeepLinkMakeCall = false
       clearUrlParams()
     }
-    // handle deep link: make call
+    // handle deep link: make call from phoneappli app
     if (number) {
       // prevent double start call and check list account
       if (this.alreadyHandleDeepLinkMakeCall || !accountStore.accounts.length) {
@@ -379,16 +381,16 @@ export class AuthStore {
       return true
     }
 
-    if (!tenant || !user) {
-      return false
-    }
-
     // handle deep link: update account (try to keep old logic)
     if (
       Object.keys(getCallStore().callkeepMap).length ||
       sip.phone?.getSessionCount() ||
       getCallStore().calls.length
     ) {
+      return false
+    }
+
+    if (!tenant || !user) {
       return false
     }
 

--- a/src/stores/authStore2.ts
+++ b/src/stores/authStore2.ts
@@ -494,7 +494,7 @@ export class AuthStore {
     await this.signIn(acc)
   }
   phoneappliEnabled = () =>
-    this.getCurrentAccount().phoneappliEnabled && Platform.OS !== 'web'
+    this.userExtensionProperties?.phoneappli && Platform.OS !== 'web'
   userExtensionProperties: null | {
     id: string
     name: string

--- a/src/stores/callStore2.ts
+++ b/src/stores/callStore2.ts
@@ -295,6 +295,7 @@ export class CallStore {
           e.remoteVideoStreamObject ? e.remoteVideoStreamObject.toURL() : '',
         )
       }
+
       if (e.talkingImageUrl && e.talkingImageUrl.length > 0) {
         BrekekeUtils.setTalkingAvatar(
           e.callkeepUuid,
@@ -302,6 +303,7 @@ export class CallStore {
           e.partyImageSize === 'large',
         )
       }
+
       if (
         e.incoming &&
         e.callkeepUuid &&
@@ -331,6 +333,7 @@ export class CallStore {
           const talkingImageUrl = res?.image_url || c.talkingImageUrl
           const partyName = res?.display_name || c.partyName
           const partyImageSize = res?.image_url ? 'large' : c.partyImageSize
+
           Object.assign(c, {
             partyImageUrl,
             talkingImageUrl,
@@ -339,6 +342,11 @@ export class CallStore {
             phoneappliAvatar: res?.image_url,
             phoneappliUsername: res?.display_name,
           })
+          BrekekeUtils.setTalkingAvatar(
+            c.callkeepUuid,
+            c.talkingImageUrl,
+            c.partyImageSize === 'large',
+          )
         })
     }
 

--- a/src/utils/RnNativeModules.ts
+++ b/src/utils/RnNativeModules.ts
@@ -38,6 +38,7 @@ type TBrekekeUtils = {
   hasIncomingCallActivity(uuid: string): Promise<boolean>
   insertCallLog(number: string, type: CallLogType): void
   setPhoneappliEnabled(enabled: boolean): void
+
   // these methods only available on ios
   webrtcSetAudioEnabled(enabled: boolean): void
   playRBT(): void
@@ -90,6 +91,7 @@ const Polyfill: TBrekekeUtils = {
   hasIncomingCallActivity: () => Promise.resolve(false),
   insertCallLog: () => undefined,
   setPhoneappliEnabled: () => undefined,
+
   // these methods only available on ios
   webrtcSetAudioEnabled: () => undefined,
   playRBT: () => undefined,

--- a/src/utils/RnNativeModules.ts
+++ b/src/utils/RnNativeModules.ts
@@ -37,7 +37,7 @@ type TBrekekeUtils = {
   onPageCallManage(uuid: string): void
   hasIncomingCallActivity(uuid: string): Promise<boolean>
   insertCallLog(number: string, type: CallLogType): void
-
+  setPhoneappliEnabled(enabled: boolean): void
   // these methods only available on ios
   webrtcSetAudioEnabled(enabled: boolean): void
   playRBT(): void
@@ -89,7 +89,7 @@ const Polyfill: TBrekekeUtils = {
   onPageCallManage: () => undefined,
   hasIncomingCallActivity: () => Promise.resolve(false),
   insertCallLog: () => undefined,
-
+  setPhoneappliEnabled: () => undefined,
   // these methods only available on ios
   webrtcSetAudioEnabled: () => undefined,
   playRBT: () => undefined,

--- a/src/utils/checkImageUrl.ts
+++ b/src/utils/checkImageUrl.ts
@@ -1,6 +1,11 @@
 import Url from 'url-parse'
 
-export const checkImageUrl = (url: string) => {
+import { getAuthStore } from '../stores/authStore'
+
+export const checkImageUrl = async (url: string) => {
+  if (getAuthStore().phoneappliEnabled()) {
+    return true
+  }
   url = url.toLowerCase()
   const u = new Url(url)
   return (

--- a/src/utils/checkImageUrl.ts
+++ b/src/utils/checkImageUrl.ts
@@ -2,7 +2,7 @@ import Url from 'url-parse'
 
 import { getAuthStore } from '../stores/authStore'
 
-export const checkImageUrl = async (url: string) => {
+export const checkImageUrl = (url: string) => {
   if (getAuthStore().phoneappliEnabled()) {
     return true
   }

--- a/src/utils/deeplink-parse.ts
+++ b/src/utils/deeplink-parse.ts
@@ -52,5 +52,4 @@ export interface UrlParams {
   phone_idx: string
   _wn: string
   number: string | undefined
-  type: string | undefined
 }

--- a/src/utils/deeplink-parse.ts
+++ b/src/utils/deeplink-parse.ts
@@ -51,4 +51,6 @@ export interface UrlParams {
   port: string
   phone_idx: string
   _wn: string
+  number: string | undefined
+  type: string | undefined
 }

--- a/src/utils/deeplink.ts
+++ b/src/utils/deeplink.ts
@@ -8,8 +8,8 @@ let alreadyHandleFirstOpen = false
 let urlParams: Promise<UrlParams | null> | UrlParams | null = null
 export const URLSchemes = {
   phoneappli: {
-    USERS: 'deeplink://directory?type=users',
-    HISTORY_CALLED: 'deeplink://history?type=called',
+    USERS: 'pa-rtk://directory?type=users',
+    HISTORY_CALLED: 'pa-rtk://history?type=called',
   },
 }
 

--- a/src/utils/deeplink.ts
+++ b/src/utils/deeplink.ts
@@ -6,7 +6,12 @@ import { parse, UrlParams } from './deeplink-parse'
 
 let alreadyHandleFirstOpen = false
 let urlParams: Promise<UrlParams | null> | UrlParams | null = null
-
+export const URLSchemes = {
+  phoneappli: {
+    USERS: 'deeplink://directory?type=users',
+    HISTORY_CALLED: 'deeplink://history?type=called',
+  },
+}
 export const getUrlParams = async () => {
   if (alreadyHandleFirstOpen) {
     return urlParams
@@ -32,4 +37,7 @@ export const getUrlParams = async () => {
   })
   urlParams = Linking.getInitialURL().then(parse)
   return urlParams
+}
+export const clearUrlParams = () => {
+  urlParams = null
 }

--- a/src/utils/deeplink.ts
+++ b/src/utils/deeplink.ts
@@ -12,6 +12,17 @@ export const URLSchemes = {
     HISTORY_CALLED: 'deeplink://history?type=called',
   },
 }
+
+export const openLinkSafely = async (url: string) => {
+  if (!url) {
+    return
+  }
+  try {
+    await Linking.openURL(url)
+  } catch (error) {
+    console.log(`Open ${url} get error: ${error}`)
+  }
+}
 export const getUrlParams = async () => {
   if (alreadyHandleFirstOpen) {
     return urlParams

--- a/src/utils/deeplink.ts
+++ b/src/utils/deeplink.ts
@@ -19,8 +19,8 @@ export const openLinkSafely = async (url: string) => {
   }
   try {
     await Linking.openURL(url)
-  } catch (error) {
-    console.log(`Open ${url} get error: ${error}`)
+  } catch (err) {
+    console.error(`Linking.openURL ${url} error: `, err)
   }
 }
 export const getUrlParams = async () => {


### PR DESCRIPTION
Integrating a phonebook application called "PhoneAppli" :
- Fix Url schemes not working with text include _ on ios
- Add config deeplink for android
- Handle make call from deeplink
- Handle transfer call from deeplink
- Update switch to other app use deeplink
- Update phoneappliEnabled property for Account
- Move voicemail to a separate tab
- Add default tab call is keypad
- Update actionBack for PageCallManage screen
- Handle get url image and url username and update to Call object for call with phoneappli enabled
- Add getPhoneappliContact method
- Show avatar and username on transfer call screen
- Update logic: Always use first account to make call when Url schemes phoneappli excute
- Keep logic for url schemes have params with host, user, tenant, port