### PR TITLE
Fix issue #851: Cannot connect call well when using 3pcc with page=true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 2.14.3
+
+- Fix android it should display UI correctly with auto answer (issue 851)
+
 #### 2.14.2
 
 - Update intl local language labels

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -64,8 +64,8 @@ android {
     minSdkVersion rootProject.ext.minSdkVersion
     targetSdkVersion rootProject.ext.targetSdkVersion
     multiDexEnabled true
-    versionCode 214002
-    versionName "2.14.2"
+    versionCode 214003
+    versionName "2.14.3"
   }
 
   signingConfigs {

--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -931,7 +931,6 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
   }
 
   public void onCallConnected() {
-
     if (!answered) {
       setCallAnswered();
     }

--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -931,8 +931,12 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
   }
 
   public void onCallConnected() {
+
     if (!answered) {
       setCallAnswered();
+    }
+    if (vCallManageLoading.getVisibility() == View.GONE) {
+      return;
     }
     long answeredAt = System.currentTimeMillis();
     startTimer(answeredAt);

--- a/ios/BrekekePhone.xcodeproj/project.pbxproj
+++ b/ios/BrekekePhone.xcodeproj/project.pbxproj
@@ -816,7 +816,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift$(inherited)";
-				MARKETING_VERSION = 2.14.2;
+				MARKETING_VERSION = 2.14.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brekeke.phonedev.BrekekeLPCExtension;
@@ -858,7 +858,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift$(inherited)";
-				MARKETING_VERSION = 2.14.2;
+				MARKETING_VERSION = 2.14.3;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brekeke.phonedev.BrekekeLPCExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/BrekekePhone/Info.plist
+++ b/ios/BrekekePhone/Info.plist
@@ -23,7 +23,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.14.2</string>
+    <string>2.14.3</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brekekephone",
-  "version": "2.14.2",
+  "version": "2.14.3",
   "private": true,
   "homepage": "./",
   "scripts": {

--- a/src/utils/callkeep.ts
+++ b/src/utils/callkeep.ts
@@ -244,7 +244,7 @@ export const setupCallKeepEvents = async () => {
   const eventEmitter = new NativeEventEmitter(BrekekeUtils)
   eventEmitter.addListener('answerCall', (uuid: string) => {
     const c = cs.calls.find(_ => _.callkeepUuid === uuid)
-    // with auto answer available, should be update UI after answer
+    // should update the native android UI here to fix a case with auto answer
     if (c && c.answered) {
       BrekekeUtils.onCallConnected(uuid)
     }

--- a/src/utils/callkeep.ts
+++ b/src/utils/callkeep.ts
@@ -243,6 +243,11 @@ export const setupCallKeepEvents = async () => {
   // events from our custom BrekekeUtils module
   const eventEmitter = new NativeEventEmitter(BrekekeUtils)
   eventEmitter.addListener('answerCall', (uuid: string) => {
+    const c = cs.calls.find(_ => _.callkeepUuid === uuid)
+    // with auto answer available, should be update UI after answer
+    if (c && c.answered) {
+      BrekekeUtils.onCallConnected(uuid)
+    }
     cs.onCallKeepAnswerCall(uuid.toUpperCase())
     RNCallKeep.setOnHold(uuid, false)
   })

--- a/src/utils/callkeep.ts
+++ b/src/utils/callkeep.ts
@@ -243,9 +243,8 @@ export const setupCallKeepEvents = async () => {
   // events from our custom BrekekeUtils module
   const eventEmitter = new NativeEventEmitter(BrekekeUtils)
   eventEmitter.addListener('answerCall', (uuid: string) => {
-    const c = cs.calls.find(_ => _.callkeepUuid === uuid)
     // should update the native android UI here to fix a case with auto answer
-    if (c && c.answered) {
+    if (cs.calls.find(_ => _.callkeepUuid === uuid)?.answered) {
       BrekekeUtils.onCallConnected(uuid)
     }
     cs.onCallKeepAnswerCall(uuid.toUpperCase())


### PR DESCRIPTION
## Steps:

### 1. Setting for 3 Pcc client IP pattern.
                        
PBX > Tenants > [tested tenant] > [Options] > [Settings] > [Valid 3pcc client IP pattern] =  ^.+$
At tested tenant Options page, set "Valid 3pcc client IP pattern" as ^.+$

### 2. Login brekeke phone (ex: 101 with phone type2)
### 3. Make call using 3PCC with page=true by sending this command 

from Web browswer.
https:/<PBX url>:<port>/pbx/3pcc?tenant=<tested tenant>=<caller>&to=<callee>&from=<caller>&page=true&type=2&phone=<phone ID is using of Caller>

Ex:  https://test1.brekeke.vn/pbx/3pcc?tenant=bphone&user=101&to=103&from=101&page=true&type=2&phone=2

=> Call is make between 101 (brekeke phone) and 103
### 4. Brekeke phone 101 and 103 answer incoming call.

=> It shows call is connecting on Brekeke phone" 101 even the call already connected.

*** If check with kill mode (kill at step2), some time call is connected well.