### PR TITLE
Fix issue #856: When tapping the missedcall notification, Brekeke phone does not move to Call history screen of PhoneAppli app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### 2.14.3
 
 - Fix it should display well with html characters < >
+- Fix it should navigate to PhoneAppli if enabled and tapping on a missed call notification (issue 856)
 - Fix android it should handle the case user reject permission default dialer phone app (issue 855)
 - Fix ios it should show LPC PN message for UC chat when it goes offline (issue 853)
 - Fix android it should display UI correctly with auto answer (issue 851)

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -304,7 +304,7 @@ PODS:
     - React-Core
   - react-native-netinfo (9.4.1):
     - React-Core
-  - react-native-notifications (4.3.5):
+  - react-native-notifications (5.1.0):
     - React-Core
   - react-native-splash-screen (3.3.0):
     - React-Core
@@ -685,7 +685,7 @@ SPEC CHECKSUMS:
   react-native-get-random-values: dee677497c6a740b71e5612e8dbd83e7539ed5bb
   react-native-image-picker: db60857e03d63721f19b6f4027de20429ddd9cba
   react-native-netinfo: fefd4e98d75cbdd6e85fc530f7111a8afdf2b0c5
-  react-native-notifications: 504143d59f9628c3b0c22fd0ccf34b65b9182d01
+  react-native-notifications: 4601a5a8db4ced6ae7cfc43b44d35fe437ac50c4
   react-native-splash-screen: 4312f786b13a81b5169ef346d76d33bc0c6dc457
   react-native-video: c26780b224543c62d5e1b2a7244a5cd1b50e8253
   react-native-webrtc: 4d1669c2ed29767fe70b0169428b4466589ecf8b

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-native-iphone-x-helper": "1.3.1",
     "react-native-keyboard-spacer": "0.4.1",
     "react-native-linear-gradient": "2.7.3",
-    "react-native-notifications": "4.3.5",
+    "react-native-notifications": "5.1.0",
     "react-native-permissions": "3.8.4",
     "react-native-share": "9.2.3",
     "react-native-splash-screen": "3.3.0",

--- a/src/components/navigationConfig.ts
+++ b/src/components/navigationConfig.ts
@@ -11,7 +11,7 @@ import { intlStore } from '../stores/intlStore'
 import { Nav } from '../stores/Nav'
 import { RnAlert } from '../stores/RnAlert'
 import { arrToMap } from '../utils/arrToMap'
-import { openLinkSafely, URLSchemes } from '../utils/deeplink'
+import { openLinkSafely, urls } from '../utils/deeplink'
 
 export type Menu = {
   key: string
@@ -148,14 +148,14 @@ const genMenus = (customPages: PbxCustomPage[]) => {
         // handle link to phoneappli app
         if (as.phoneappliEnabled()) {
           if (s.navFnKey === 'goToPageContactPhonebook') {
-            openLinkSafely(URLSchemes.phoneappli.USERS)
+            openLinkSafely(urls.phoneappli.USERS)
             return
           }
           if (
             s.navFnKey === 'goToPageCallRecents' ||
             s.navFnKey === 'backToPageCallRecents'
           ) {
-            openLinkSafely(URLSchemes.phoneappli.HISTORY_CALLED)
+            openLinkSafely(urls.phoneappli.HISTORY_CALLED)
             return
           }
         }

--- a/src/components/navigationConfig2.ts
+++ b/src/components/navigationConfig2.ts
@@ -6,7 +6,7 @@ import { intl } from '../stores/intl'
 import { RnAlert } from '../stores/RnAlert'
 import { RnStacker } from '../stores/RnStacker'
 import { arrToMap } from '../utils/arrToMap'
-import { openLinkSafely, URLSchemes } from '../utils/deeplink'
+import { openLinkSafely, urls } from '../utils/deeplink'
 import { Menu, SubMenu } from './navigationConfig'
 
 let PageCallTransferChooseUser: ReactComponentLike
@@ -63,7 +63,7 @@ export const getTabs = (tab: string) => {
         const name = Object.keys(s.navFnKey)[0]
         // handle link to phoneappli app
         if (!name || s.key === 'phonebook') {
-          openLinkSafely(URLSchemes.phoneappli.USERS)
+          openLinkSafely(urls.phoneappli.USERS)
           return
         }
         // @ts-ignore

--- a/src/utils/PushNotification-parse.ts
+++ b/src/utils/PushNotification-parse.ts
@@ -7,7 +7,7 @@ import { getAuthStore } from '../stores/authStore'
 import { getCallStore } from '../stores/callStore'
 import { chatStore } from '../stores/chatStore'
 import { Nav } from '../stores/Nav'
-import { openLinkSafely, URLSchemes } from './deeplink'
+import { openLinkSafely, urls } from './deeplink'
 import { BrekekeUtils } from './RnNativeModules'
 import { toBoolean } from './string'
 import { waitTimeout } from './waitTimeout'
@@ -239,7 +239,7 @@ export const parse = async (
     )
     if (as.phoneappliEnabled()) {
       navIndex('goToPageCallKeypad')
-      openLinkSafely(URLSchemes.phoneappli.HISTORY_CALLED)
+      openLinkSafely(urls.phoneappli.HISTORY_CALLED)
     } else {
       navIndex('goToPageCallRecents')
     }

--- a/src/utils/PushNotification-parse.ts
+++ b/src/utils/PushNotification-parse.ts
@@ -7,6 +7,7 @@ import { getAuthStore } from '../stores/authStore'
 import { getCallStore } from '../stores/callStore'
 import { chatStore } from '../stores/chatStore'
 import { Nav } from '../stores/Nav'
+import { openLinkSafely, URLSchemes } from './deeplink'
 import { BrekekeUtils } from './RnNativeModules'
 import { toBoolean } from './string'
 import { waitTimeout } from './waitTimeout'
@@ -236,7 +237,12 @@ export const parse = async (
     console.log(
       'SIP PN debug: PushNotification-parse: local notification missed call',
     )
-    navIndex('goToPageCallRecents')
+    if (as.phoneappliEnabled()) {
+      navIndex('goToPageCallKeypad')
+      openLinkSafely(URLSchemes.phoneappli.HISTORY_CALLED)
+    } else {
+      navIndex('goToPageCallRecents')
+    }
     return
   }
 

--- a/src/utils/deeplink.ts
+++ b/src/utils/deeplink.ts
@@ -4,9 +4,7 @@ import { compareAccount } from '../stores/accountStore'
 import { getAuthStore } from '../stores/authStore'
 import { parse, UrlParams } from './deeplink-parse'
 
-let alreadyHandleFirstOpen = false
-let urlParams: Promise<UrlParams | null> | UrlParams | null = null
-export const URLSchemes = {
+export const urls = {
   phoneappli: {
     USERS: 'pa-rtk://directory?type=users',
     HISTORY_CALLED: 'pa-rtk://history?type=called',
@@ -23,6 +21,9 @@ export const openLinkSafely = async (url: string) => {
     console.error(`Linking.openURL ${url} error: `, err)
   }
 }
+
+let alreadyHandleFirstOpen = false
+let urlParams: Promise<UrlParams | null> | UrlParams | null = null
 export const getUrlParams = async () => {
   if (alreadyHandleFirstOpen) {
     return urlParams

--- a/yarn.lock
+++ b/yarn.lock
@@ -10516,10 +10516,10 @@ react-native-linear-gradient@2.7.3:
   resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.7.3.tgz#f77b71ed7c955e033f9cba5fc8478df57953eb27"
   integrity sha512-iyJszlZ1Ech2c+2qV+isMvvJKyoctR9ashDkhJg1/cuSF0vQaeLV1FAYTT3qW9doxChJGxVAFfYoxotH0yi3Iw==
 
-react-native-notifications@4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/react-native-notifications/-/react-native-notifications-4.3.5.tgz#90c7f3b1b248f6628c8efc8cafab4fd464ce3e5a"
-  integrity sha512-tCKkPaauN8/RIwPTeWdyezHXt5i4iDJViZGZ7/EBBuHB9kl9Oq3UjKFZeDfnM4DmJt+m7K2FQ7NaAuh3Kg1FCA==
+react-native-notifications@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-notifications/-/react-native-notifications-5.1.0.tgz#8cba105fd57ab9d5df9d27284acf1e2b4f3d7ea3"
+  integrity sha512-laqDSDlCvEASmJR6cXpqaryK855ejQd07vrfYERzhv68YDOoSkKy/URExRP4vAfAOVqHhix80tLbNUcfvZk2VQ==
 
 react-native-permissions@3.8.4:
   version "3.8.4"


### PR DESCRIPTION
## Fix isssue:
- When tapping the notification shown within the "Who Called" function with the PHONE APP integration, the history screen of BrekekePhone is displayed. I would like it to switch to the history screen of PHONE APP instead.
- Update lib to fix issue: https://github.com/wix/react-native-notifications/pull/983