### PR TITLE
Fix issue #740: Layout not good when keyboard open 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### 2.14.3
 
 - Fix android it should display UI correctly with auto answer (issue 851)
+- Fix it should display layout better when keyboard open in call with X-PBX-IMAGE-TALKING and long name (issue 740)
 
 #### 2.14.2
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -67,6 +67,7 @@
       android:showOnLockScreen="true"
       android:screenOrientation="sensorPortrait"
       android:autoRemoveFromRecents="true"
+      android:windowSoftInputMode="adjustPan"
     />
     <activity
       android:name=".ExitActivity"

--- a/android/app/src/main/res/layout/incoming_call_activity.xml
+++ b/android/app/src/main/res/layout/incoming_call_activity.xml
@@ -39,6 +39,8 @@
         android:textSize="20dp"
         android:textColor="@color/black"
         android:textStyle="bold"
+        android:maxLines="1"
+        android:ellipsize="end"
       />
     </LinearLayout>
     <!-- view_webrtc_video -->
@@ -131,6 +133,7 @@
             android:layout_marginTop="20dp"
             android:gravity="center"
             android:maxLines="2"
+            android:ellipsize="end"
             android:paddingHorizontal="20dp"
             android:text="Caller Name"
             android:textColor="@color/white"
@@ -250,6 +253,9 @@
               android:textColor="@color/white"
               android:textSize="22dp"
               android:textStyle="bold"
+              android:maxLines="2"
+              android:ellipsize="end"
+              android:paddingHorizontal="20dp"
             />
             <TextView
               android:id="@+id/txt_count_timer"

--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -128,6 +128,8 @@ const css = StyleSheet.create({
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'flex-start',
+    minHeight: Dimensions.get('window').height * 0.4,
+    minWidth: Dimensions.get('window').height * 0.4,
   },
   ImageSize: {
     height: 130,


### PR DESCRIPTION
1. Webview is configured in dialplan: X-PBX-IMAGE-TALKING = https://test1.brekeke.vn/uc/wws?t=tenant1&w=8f54db499262e2e8300ea5ce7811301e
1. Android13 A log in brekeke phone.
2. A phonebook name B extension with long name.
3. B call to A and A answer.
=> A&B talking well.
=> Webview appear on A screen with B display name in phonebook.
