### PR TITLE
Fix issue #752: Double vibration in popup notification on top screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix it should display well with html characters < >
 - Fix android it should display UI correctly with auto answer (issue 851)
+- Fix android it should have single vibration on notification instead of double (issue 752)
 - Fix it should display layout better when keyboard open in call with X-PBX-IMAGE-TALKING and long name (issue 740)
 
 #### 2.14.2

--- a/src/utils/PushNotification.android.ts
+++ b/src/utils/PushNotification.android.ts
@@ -99,7 +99,7 @@ export const PushNotification = {
         // showBadge: true,
         // place this in android/app/src/main/res/raw/ding.mp3
         // soundFile: 'ding.mp3',
-        vibrationPattern: [200, 1000, 500, 1000, 500],
+        vibrationPattern: [200, 1000],
       })
 
       // set notification channel for chat
@@ -114,7 +114,7 @@ export const PushNotification = {
         // groupName: 'My Group',
         // showBadge: true,
         soundFile: 'ding.mp3',
-        vibrationPattern: [200, 1000, 500, 1000, 500],
+        vibrationPattern: [200, 1000],
       })
 
       // handle received PN


### PR DESCRIPTION
## Step
(1) A (Android13) log in brekeke phone and change app to background.
(2) B call to A
=> A receive PN call.
(3) B disconnect call.
=> A receive miss call notification on top screen.
Issue: Notification come with double time vibration.

** Previously it come with single time vibration.
** In step2, if B send A a message, A receive message notification with doulbe time vibration too.