### PR TITLE
Fix issue #853: LPC - Not showing PN message in case UC becomes offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix it should display well with html characters < >
 - Fix android it should handle the case user reject permission default dialer phone app (issue 855)
+- Fix ios it should show LPC PN message for UC chat when it goes offline (issue 853)
 - Fix android it should display UI correctly with auto answer (issue 851)
 - Fix android it should not play notification sound if phone is in vibration mode (issue 756)
 - Fix android it should have single vibration on notification instead of double (issue 752)

--- a/ios/BrekekeLPC/Networking/RequestResponseSession.swift
+++ b/ios/BrekekeLPC/Networking/RequestResponseSession.swift
@@ -236,16 +236,16 @@ public class RequestResponseSession: NetworkSession {
     }
   }
 
-//    response data:
-//      {
-//        routing:{
-//          receiver:{},
-//          sender:{}
-//        },
-//      custom:{PN chat data || PN incoming call data},
-//      message:""
-//    }
-
+  // {
+  //   routing: {
+  //     receiver: {},
+  //     sender: {},
+  //   },
+  //   /* PN data, can be chat or incoming call */
+  //   custom: {},
+  //   /* PN message */
+  //   message: "",
+  // }
   private func decode(data: Data) -> Wrapper? {
     do {
       let wrapper = try decoder.decode(Wrapper.self, from: data)
@@ -269,7 +269,7 @@ public class RequestResponseSession: NetworkSession {
             ) as? [AnyHashable: Any] {
               if var custom = json["custom"] as? [AnyHashable: Any] {
                 custom["callkeepUuid"] = UUID().uuidString.uppercased()
-                custom["body"] = json["message"] ?? ""
+                custom["body"] = json["message"] ?? "UC message"
                 msg.custom = custom
               }
             }

--- a/ios/BrekekeLPC/Networking/RequestResponseSession.swift
+++ b/ios/BrekekeLPC/Networking/RequestResponseSession.swift
@@ -236,6 +236,16 @@ public class RequestResponseSession: NetworkSession {
     }
   }
 
+//    response data:
+//      {
+//        routing:{
+//          receiver:{},
+//          sender:{}
+//        },
+//      custom:{PN chat data || PN incoming call data},
+//      message:""
+//    }
+
   private func decode(data: Data) -> Wrapper? {
     do {
       let wrapper = try decoder.decode(Wrapper.self, from: data)
@@ -250,9 +260,7 @@ public class RequestResponseSession: NetworkSession {
           for: payload.codingKey,
           data: payload.data
         )
-        logger.log(".request message: \(message)")
         if var msg = message as? TextMessage {
-          logger.log(".request message as")
           let datajson = String(data: payload.data, encoding: .utf8)
           if var datajson = datajson {
             if let json = try JSONSerialization.jsonObject(
@@ -261,6 +269,7 @@ public class RequestResponseSession: NetworkSession {
             ) as? [AnyHashable: Any] {
               if var custom = json["custom"] as? [AnyHashable: Any] {
                 custom["callkeepUuid"] = UUID().uuidString.uppercased()
+                custom["body"] = json["message"] ?? ""
                 msg.custom = custom
               }
             }

--- a/ios/BrekekePhone/BrekekeLPCManager.swift
+++ b/ios/BrekekePhone/BrekekeLPCManager.swift
@@ -227,8 +227,15 @@ extension BrekekeLPCManager: NEAppPushDelegate {
       let content = UNMutableNotificationContent()
       let body = payload["body"] as! String
       let matched = body.match("from (.*?):(.*?)$")
-      content.title = matched[0][1]
-      content.body = matched[0][2]
+      if let firstMatch = matched.first,
+         let title = firstMatch.indices.contains(1) ? firstMatch[1] : nil {
+        content.title = title
+      } else if let senderUserName = payload["senderUserName"] as? String {
+        content.title = senderUserName
+      } else {
+        content.title = ""
+      }
+      content.body = body
       content.sound = .default
       content.userInfo = payload
       content.sound = UNNotificationSound.default

--- a/ios/BrekekePhone/BrekekeLPCManager.swift
+++ b/ios/BrekekePhone/BrekekeLPCManager.swift
@@ -233,7 +233,7 @@ extension BrekekeLPCManager: NEAppPushDelegate {
       } else if let senderUserName = payload["senderUserName"] as? String {
         content.title = senderUserName
       } else {
-        content.title = ""
+        content.title = "UC message"
       }
       content.body = body
       content.sound = .default

--- a/src/utils/PushNotification.ios.ts
+++ b/src/utils/PushNotification.ios.ts
@@ -71,7 +71,6 @@ const onNotification = async (
     withCallKeepUuid.callkeepUuid = withDictionaryPayload.callkeepUuid
   }
   await initApp()
-  // when click notification isLocal is true
   await parse(withCallKeepUuid, isLocal, isLocal)
 }
 

--- a/src/utils/PushNotification.ios.ts
+++ b/src/utils/PushNotification.ios.ts
@@ -71,7 +71,8 @@ const onNotification = async (
     withCallKeepUuid.callkeepUuid = withDictionaryPayload.callkeepUuid
   }
   await initApp()
-  await parse(withCallKeepUuid, isLocal, true)
+  // when click notification isLocal is true
+  await parse(withCallKeepUuid, isLocal, isLocal)
 }
 
 export const PushNotification = {


### PR DESCRIPTION
## Step
(1) Set only LPC mode on PBX (set webphone.lpc.pn=false in PBX advanced options)
(2) Login Brekeke phone then kill it
(3) Send PN message to the brekeke phone.
=> The pn message does not show on phone
*** The same problem happens in case UC become offline after putting the phone in background mode, or lock the phone screen.