### PR TITLE
Fix issue #860: The PHONE APPLI image may not be displayed on the android BrekekePhone's incoming call screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### 2.14.3
 
 - Fix it should display well with html characters < >
+- Fix it should not display avatar twice in case PhoneAppli enabled (issue 860)
 - Fix it should navigate to PhoneAppli if enabled and tapping on a missed call notification (issue 856)
 - Fix android it should handle the case user reject permission default dialer phone app (issue 855)
 - Fix ios it should show LPC PN message for UC chat when it goes offline (issue 853)

--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -626,7 +626,7 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
 
   public void handleShowAvatarTalking() {
     destroyAvatarWebView();
-    if (BrekekeUtils.phoneappliEnabled || BrekekeUtils.isImageUrl(talkingAvatar)) {
+    if (BrekekeUtils.isImageUrl(talkingAvatar)) {
       webViewAvatarTalking.setVisibility(View.GONE);
       imgAvatarTalking.setVisibility(View.VISIBLE);
       Glide.with(this)

--- a/src/components/SmartImage.tsx
+++ b/src/components/SmartImage.tsx
@@ -11,6 +11,7 @@ import { WebViewNavigationEvent } from 'react-native-webview/lib/WebViewTypes'
 
 import noPhoto from '../assets/no_photo.png'
 import { buildWebViewSource } from '../config'
+import { getAuthStore } from '../stores/authStore'
 import { checkImageUrl } from '../utils/checkImageUrl'
 import { webviewInjectSendJsonToRnOnLoad } from './webviewInjectSendJsonToRnOnLoad'
 
@@ -61,7 +62,15 @@ enum StatusImage {
   loaded = 1,
   error = 2,
 }
-export const SmartImage = ({ uri, style }: { uri: string; style: object }) => {
+export const SmartImage = ({
+  uri,
+  style,
+  incoming,
+}: {
+  uri: string
+  style: object
+  incoming: boolean
+}) => {
   const [statusImageLoading, setStatusImageLoading] = useState(
     StatusImage.loading,
   )
@@ -115,7 +124,8 @@ export const SmartImage = ({ uri, style }: { uri: string; style: object }) => {
   const onHttpError = () => {
     setStatusImageLoading(StatusImage.loaded)
   }
-  const isImageUrl = checkImageUrl(uri)
+  const isImageUrl =
+    (getAuthStore().phoneappliEnabled() && !incoming) || checkImageUrl(uri)
 
   return (
     <View style={[css.image, style]}>

--- a/src/components/SmartImage.web.tsx
+++ b/src/components/SmartImage.web.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { ActivityIndicator, Image, StyleSheet, View } from 'react-native'
 
 import noPhoto from '../assets/no_photo.png'
+import { getAuthStore } from '../stores/authStore'
 import { checkImageUrl } from '../utils/checkImageUrl'
 
 const noPhotoImg = typeof noPhoto === 'string' ? { uri: noPhoto } : noPhoto
@@ -34,7 +35,11 @@ const css = StyleSheet.create({
   },
 })
 
-export const SmartImage = (p: { uri: string; style: object }) => {
+export const SmartImage = (p: {
+  uri: string
+  style: object
+  incoming: boolean
+}) => {
   const [statusImageLoading, setStatusImageLoading] = useState(0)
   const [size, setSize] = useState(0)
   useEffect(() => {
@@ -51,7 +56,8 @@ export const SmartImage = (p: { uri: string; style: object }) => {
     setStatusImageLoading(1)
   }
 
-  const isImageUrl = checkImageUrl(p.uri)
+  const isImageUrl =
+    (getAuthStore().phoneappliEnabled() && !p.incoming) || checkImageUrl(p.uri)
 
   return (
     <View

--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -486,6 +486,7 @@ class PageCallManage extends Component<{
               key={c.talkingImageUrl}
               uri={`${c.talkingImageUrl}`}
               style={{ flex: 1, aspectRatio: 1 }}
+              incoming={c.incoming}
             />
           )}
           {!c.answered && (
@@ -493,6 +494,7 @@ class PageCallManage extends Component<{
               key={c.partyImageUrl}
               uri={`${c.partyImageUrl}`}
               style={{ flex: 1, aspectRatio: 1 }}
+              incoming={c.incoming}
             />
           )}
         </View>

--- a/src/stores/callStore2.ts
+++ b/src/stores/callStore2.ts
@@ -280,8 +280,8 @@ export class CallStore {
         withSDPControls: e.withSDPControls || p.withSDP,
       })
 
-      // handle always show Avatar and Username when phoneappli enabled
-      if (auth.phoneappliEnabled()) {
+      // handle always show Avatar and Username when phoneappli enabled with outgoing call
+      if (auth.phoneappliEnabled() && !e.incoming) {
         Object.assign(e, {
           partyImageUrl: e.phoneappliAvatar || p.partyImageUrl,
           talkingImageUrl: e.phoneappliAvatar || p.talkingImageUrl,
@@ -324,7 +324,7 @@ export class CallStore {
     Object.assign(c, p)
 
     // get Avatar and Username of phoneappli
-    if (auth.phoneappliEnabled()) {
+    if (auth.phoneappliEnabled() && !c.incoming) {
       const { pbxTenant, pbxUsername } = auth.getCurrentAccount()
       pbx
         .getPhoneappliContact(pbxTenant, pbxUsername, c.partyNumber)

--- a/src/utils/checkImageUrl.ts
+++ b/src/utils/checkImageUrl.ts
@@ -1,11 +1,6 @@
 import Url from 'url-parse'
 
-import { getAuthStore } from '../stores/authStore'
-
 export const checkImageUrl = (url: string) => {
-  if (getAuthStore().phoneappliEnabled()) {
-    return true
-  }
   url = url.toLowerCase()
   const u = new Url(url)
   return (


### PR DESCRIPTION
## Step
When receiving a call, the URL is notified in the INVITE's X-PBX-IMAGE-RINGING and X-PBX-IMAGE-TALKING headers, so it seems that the URL is not being displayed correctly because it is trying to display it twice.