### PR TITLE
Fix issue 866: Brekeke phone cannot reconnect UC after app run background and restart server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### 2.14.3
 
 - Fix it should display well with html characters < >
+- Fix it should reconnect UC after put app in background and restart server (issue 866)
 - Fix it should play RBT correctly with 18x status code (issue 864)
 - Fix ios it should have call audio correctly with low latency response (issue 861, 863)
 - Fix it should not display avatar twice in case PhoneAppli enabled (issue 860)

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -134,13 +134,8 @@ class Api {
   }
   onSIPConnectionStopped = (e: { reason: string; response: string }) => {
     const s = getAuthStore()
-    if (!e?.reason && !e?.response) {
-      console.log('SIP PN debug: set sipState stopped')
-      s.sipState = 'stopped'
-    } else {
-      console.log('SIP PN debug: set sipState failure stopped')
-      s.sipState = 'failure'
-    }
+    console.log('SIP PN debug: set sipState failure stopped')
+    s.sipState = 'failure'
     s.sipTotalFailure += 1
     if (s.sipTotalFailure > 3) {
       s.sipPn = {}


### PR DESCRIPTION
### Reproduction steps:
(1) Login brekeke phone 
(2) Restart PBX server
(3) When it shows a connection message on top of Brekeke phone, lock the phone device.
(4) After PBX server is up for a while (around 1 minute), unlock the phone device.
=>  Error message "connection failed" occurs, and the brekeke phone cannot reconnect after that.