### PR TITLE
Fix issue 859: Call history content are displayed in double quotes as &quot;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix it should play RBT correctly with 18x status code (issue 864)
 - Fix ios it should have call audio correctly with low latency response (issue 861, 863)
 - Fix it should not display avatar twice in case PhoneAppli enabled (issue 860)
+- Fix it should not encode special characters (issue 859)
 - Fix it should navigate to PhoneAppli if enabled and tapping on a missed call notification (issue 856)
 - Fix android it should handle the case user reject permission default dialer phone app (issue 855)
 - Fix ios it should show LPC PN message for UC chat when it goes offline (issue 853)

--- a/src/stores/intl.ts
+++ b/src/stores/intl.ts
@@ -12,7 +12,10 @@ const compileFn = (locale: string, k: string): CompileFn => {
   const i = enLabelsMapIndex[k as keyof typeof enLabelsMapIndex]
   let fn = arr[i] as any as CompileFn
   if (!fn || typeof fn !== 'function') {
-    fn = Handlebars.compile(fn || k)
+    let msg = (fn as string) || k
+    // https://handlebarsjs.com/guide/expressions.html#html-escaping
+    msg = msg.replaceAll('{{', '{{{').replaceAll('}}', '}}}')
+    fn = Handlebars.compile(msg)
   }
   if (i !== undefined) {
     arr[i] = fn as any as string


### PR DESCRIPTION
when PHONE APPLI is not linked , the push notification content and BrekekePhone history content are displayed in double quotes as ".