### PR TITLE
Fix issue: When user received incoming call, UC should auth after run background

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -110,7 +110,7 @@ const initApp = async () => {
       return
     }
     // reconnect UC when app is active
-    authUC.authWithCheck()
+    authUC.authWithAppActive()
     s.resetFailureState()
     cs.onCallKeepAction()
     pnToken.syncForAllAccounts()

--- a/src/stores/AuthUC.ts
+++ b/src/stores/AuthUC.ts
@@ -32,7 +32,21 @@ class AuthUC {
     const s = getAuthStore()
     s.ucState = 'stopped'
   }
-
+  authWithAppActive = async () => {
+    const s = getAuthStore()
+    if (
+      s.getCurrentAccount()?.ucEnabled &&
+      s.signedInId &&
+      s.pbxState === 'success'
+    ) {
+      this.authWithoutCatch().catch(
+        action((err: Error) => {
+          s.ucState = 'failure'
+          console.error('Failed to connect to uc:', err)
+        }),
+      )
+    }
+  }
   @action private authWithoutCatch = async () => {
     uc.disconnect()
     const s = getAuthStore()


### PR DESCRIPTION
When user received incoming call, App will get background mode.
UC should auth after run background and active again