### PR TITLE
Fix issue #867: should be reset navigation if upsert new account

### DIFF
--- a/src/stores/accountStore.ts
+++ b/src/stores/accountStore.ts
@@ -174,13 +174,19 @@ class AccountStore {
 
   @action upsertAccount = async (p: Partial<Account>) => {
     const a = this.accounts.find(_ => _.id === p.id)
+
     if (!a) {
       this.accounts.push(p as Account)
       this.saveAccountsToLocalStorageDebounced()
       return
     }
+
     const clonedA = { ...a } // clone before assign
-    Object.assign(a, p)
+    // reset navigation if upsert new account
+    const navUpdate = compareAccount(a, p)
+      ? null
+      : { navIndex: -1, navSubMenus: [] }
+    Object.assign(a, p, navUpdate)
     this.saveAccountsToLocalStorageDebounced()
     // check and sync pn token
     const phoneIndexChanged =


### PR DESCRIPTION
### Step
- (1) Prepare settings for PhoneAppli, and create settings for 2 users
pbx user 101:  enabeld PhoneAppli
"PHONE APPLI PEOPLE settings": Cooperation -> yes; set proper API key
pbx user 102: disabled PhoneAppli
- (2) Login Brekeke phone with 102 (disabled phoneAppli), and open Phonebook tab in User icon.
tested user: server dev01; pbx user 102; password: 123; tenant nam
- (3) Log out 102, change account to 101 and login on Brekeke phone.
- (4) After login, tappin on an "User" icon at bottom left screen of Brekeke phone.
=> Actual: It always navigate to the PHONE APPLI PEOPLE application. (NG)