### PR TITLE
Issue #877, #889: Hang-up button cut off on pageCallManage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### 2.14.5
 
 - Fix ios it should make call correctly when invoke app immediately from PhoneAppli (issue 876)
+- Fix it should not cut off hang up button in small screen (issue 877, 889)
 
 #### 2.14.4
 

--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -50,10 +50,9 @@ import { BrekekeUtils } from '../utils/RnNativeModules'
 import { waitTimeout } from '../utils/waitTimeout'
 import { PageCallTransferAttend } from './PageCallTransferAttend'
 
-const height = Dimensions.get('window').height
-const width = Dimensions.get('window').width
-const minSizeH = height * 0.3
-const minSizeW = width * 0.8
+const { width, height } = Dimensions.get('window')
+const minSizeH = height * 0.4
+const minSizeW = width * 0.9
 const minSizeImageWrapper = minSizeH > minSizeW ? minSizeW : minSizeH
 
 const css = StyleSheet.create({
@@ -81,9 +80,6 @@ const css = StyleSheet.create({
     flex: 1,
     alignSelf: 'stretch',
   },
-  Btns: {
-    marginTop: 10,
-  },
   BtnFuncCalls: {
     marginBottom: 10,
   },
@@ -105,10 +101,6 @@ const css = StyleSheet.create({
     flex: 1,
   },
   Hangup: {
-    // position: 'absolute',
-    // bottom: 40,
-    // left: 0,
-    // right: 0,
     marginBottom: 40,
   },
   Hangup_incoming: {
@@ -536,11 +528,10 @@ class PageCallManage extends Component<{
     const isHideButtons =
       (c.incoming || (!c.withSDPControls && Platform.OS === 'web')) &&
       !c.answered
-    const incoming = c.incoming && !c.answered
     return (
       <Container
         onPress={c.localVideoEnabled ? this.toggleButtons : undefined}
-        style={[css.Btns, { marginTop: !incoming ? 30 : 0 }]}
+        style={{ marginTop: isHideButtons ? 30 : 0 }}
       >
         {n > 0 && (
           <FieldButton

--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -51,6 +51,11 @@ import { waitTimeout } from '../utils/waitTimeout'
 import { PageCallTransferAttend } from './PageCallTransferAttend'
 
 const height = Dimensions.get('window').height
+const width = Dimensions.get('window').width
+const minSizeH = height * 0.3
+const minSizeW = width * 0.8
+const minSizeImageWrapper = minSizeH > minSizeW ? minSizeW : minSizeH
+
 const css = StyleSheet.create({
   BtnSwitchCamera: {
     position: 'absolute',
@@ -128,8 +133,8 @@ const css = StyleSheet.create({
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'flex-start',
-    minHeight: Dimensions.get('window').height * 0.4,
-    minWidth: Dimensions.get('window').height * 0.4,
+    minHeight: minSizeImageWrapper,
+    minWidth: minSizeImageWrapper,
   },
   ImageSize: {
     height: 130,


### PR DESCRIPTION

Hang-up button cut off in call screen
This issue only occurs on iOS devices, specifically iPhone SE 2nd/3rd.
### step
1. Login A to brekeke phone on Iphone
 2. Set dialplan rule without X-PBX-IMAGE-SIZE tag
 3. Make multi call to A and A answers the calls
 4. Check UI on the menu call
 => End button is covered -> NG
 
![CleanShot 2024-05-25 at 07 14 47@2x](https://github.com/brekekesoftware/brekekephone/assets/5568604/1273b8f1-4d8c-46d8-9dd8-9fee19962ebd)
