### PR TITLE
Fix issue #878: PHONE APPLI image disappears during 3PCC calls with auto-answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 #### 2.14.5
 
-- Fix ios it should make call correctly when invoke app immediately from PhoneAppli (issue 876)
+- Fix android it should display PhoneAppli image correctly during 3PCC calls with auto-answer (issue 878)
 - Fix it should not cut off hang up button in small screen (issue 877, 889)
+- Fix ios it should make call correctly when invoke app immediately from PhoneAppli (issue 876)
 
 #### 2.14.4
 

--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -1085,6 +1085,10 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
   public TimerTask timerTask;
 
   public void startTimer(long answeredAt) {
+    // make sure timer task execute one time
+    if (timerTask != null) {
+      return;
+    }
     timerTask =
         new TimerTask() {
           @Override

--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -626,6 +626,11 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
 
   public void handleShowAvatarTalking() {
     destroyAvatarWebView();
+    // Some case talkingAvatar update so late with auto answer case
+    // It should be check and update layout
+    if (!isVideoCall && answered && vCardAvatarTalking.getVisibility() == View.GONE) {
+      onCallConnected();
+    }
     if (BrekekeUtils.isImageUrl(talkingAvatar)) {
       webViewAvatarTalking.setVisibility(View.GONE);
       imgAvatarTalking.setVisibility(View.VISIBLE);
@@ -933,10 +938,10 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
   public void onCallConnected() {
     if (!answered) {
       setCallAnswered();
-    }
-    if (vCallManageLoading.getVisibility() == View.GONE) {
+      // only update if answer==true
       return;
     }
+
     long answeredAt = System.currentTimeMillis();
     startTimer(answeredAt);
     vCallManageLoading.setVisibility(View.GONE);

--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -626,11 +626,6 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
 
   public void handleShowAvatarTalking() {
     destroyAvatarWebView();
-    // Some case talkingAvatar update so late with auto answer case
-    // It should be check and update layout
-    if (!isVideoCall && answered && vCardAvatarTalking.getVisibility() == View.GONE) {
-      onCallConnected();
-    }
     if (BrekekeUtils.isImageUrl(talkingAvatar)) {
       webViewAvatarTalking.setVisibility(View.GONE);
       imgAvatarTalking.setVisibility(View.VISIBLE);
@@ -938,7 +933,6 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
   public void onCallConnected() {
     if (!answered) {
       setCallAnswered();
-      // only update if answer==true
       return;
     }
 
@@ -1085,7 +1079,6 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
   public TimerTask timerTask;
 
   public void startTimer(long answeredAt) {
-    // make sure timer task execute one time
     if (timerTask != null) {
       return;
     }

--- a/android/app/src/main/res/layout/incoming_call_activity.xml
+++ b/android/app/src/main/res/layout/incoming_call_activity.xml
@@ -637,6 +637,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
+            android:visibility="gone"
           >
             <ImageView
               android:id="@+id/avatar_talking"

--- a/src/utils/callkeep.ts
+++ b/src/utils/callkeep.ts
@@ -247,6 +247,8 @@ export const setupCallKeepEvents = async () => {
     // should update the native android UI here to fix a case with auto answer
     const c = cs.calls.find(_ => _.callkeepUuid === uuid && _.answered)
     if (c) {
+      BrekekeUtils.onCallConnected(uuid)
+      // with auto answer, talkingAvatar takes too long to update
       BrekekeUtils.setTalkingAvatar(
         uuid,
         c.talkingImageUrl,

--- a/src/utils/callkeep.ts
+++ b/src/utils/callkeep.ts
@@ -245,8 +245,13 @@ export const setupCallKeepEvents = async () => {
   const eventEmitter = new NativeEventEmitter(BrekekeUtils)
   eventEmitter.addListener('answerCall', (uuid: string) => {
     // should update the native android UI here to fix a case with auto answer
-    if (cs.calls.find(_ => _.callkeepUuid === uuid)?.answered) {
-      BrekekeUtils.onCallConnected(uuid)
+    const c = cs.calls.find(_ => _.callkeepUuid === uuid && _.answered)
+    if (c) {
+      BrekekeUtils.setTalkingAvatar(
+        uuid,
+        c.talkingImageUrl,
+        c.partyImageSize === 'large',
+      )
     }
     cs.onCallKeepAnswerCall(uuid.toUpperCase())
     RNCallKeep.setOnHold(uuid, false)


### PR DESCRIPTION
When making a 3PCC call with PHONE APPLI integration and auto-answer enabled, the PHONE APPLI image is initially displayed but disappears during the call.