### PR TITLE
Fix issue 875: The incoming call image may not display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Fix android it should display PhoneAppli image correctly during 3PCC calls with auto-answer (issue 878)
 - Fix it should not cut off hang up button in small screen (issue 877, 889)
 - Fix ios it should make call correctly when invoke app immediately from PhoneAppli (issue 876)
-- Fix android it should display ringing image PhoneAppli (issue 875)
+- Fix android it should display well ringing image with PhoneAppli (issue 875)
 
 #### 2.14.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix android it should display PhoneAppli image correctly during 3PCC calls with auto-answer (issue 878)
 - Fix it should not cut off hang up button in small screen (issue 877, 889)
 - Fix ios it should make call correctly when invoke app immediately from PhoneAppli (issue 876)
+- Fix android it should display ringing image PhoneAppli (issue 875)
 
 #### 2.14.4
 

--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -625,7 +625,6 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
   }
 
   public void handleShowAvatarTalking() {
-    destroyAvatarWebView();
     if (BrekekeUtils.isImageUrl(talkingAvatar)) {
       webViewAvatarTalking.setVisibility(View.GONE);
       imgAvatarTalking.setVisibility(View.VISIBLE);
@@ -928,6 +927,8 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
     vHeaderIncomingCall.setVisibility(View.GONE);
     vCallManage.setVisibility(View.VISIBLE);
     vNavHeader.setVisibility(View.VISIBLE);
+    // Should be clean up Webview avatar incoming call
+    destroyAvatarWebView();
   }
 
   public void onCallConnected() {

--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -927,7 +927,6 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
     vHeaderIncomingCall.setVisibility(View.GONE);
     vCallManage.setVisibility(View.VISIBLE);
     vNavHeader.setVisibility(View.VISIBLE);
-    // Should be clean up Webview avatar incoming call
     destroyAvatarWebView();
   }
 


### PR DESCRIPTION
### Step
- Login Brekeke phone (set with PhoneAppli) and put it in background and wait until UC offline.
- Make call to the Brekeke phone.
=> Issue: While the call is ringing it does not show avatar (image set in PhoneAppli) 
The avatar only shows after answered the call.
*** Note: the issue is reproduced with Android, and rate is around 100%.