### PR TITLE
Fix issue #885: Custom page is not reloaded after reconnected to PBX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 #### 2.14.5
 
+- Fix it should display well custom page when pbx reconnect (issue 885)
 - Fix android it should display PhoneAppli image correctly during 3PCC calls with auto-answer (issue 878)
 - Fix it should not cut off hang up button in small screen (issue 877, 889)
 - Fix ios it should make call correctly when invoke app immediately from PhoneAppli (issue 876)

--- a/src/pages/PageCustomPageView.tsx
+++ b/src/pages/PageCustomPageView.tsx
@@ -4,6 +4,7 @@ import { StyleSheet } from 'react-native'
 
 import { isCustomPageUrlBuilt } from '../api/customPage'
 import {
+  buildCustomPageUrl,
   rebuildCustomPageUrlNonce,
   rebuildCustomPageUrlPbxToken,
 } from '../api/pbx'
@@ -54,6 +55,14 @@ export class PageCustomPageView extends Component<{ id: string }> {
     if (!cp) {
       return
     }
+
+    // It should be checked whether the URL is built or not
+    if (!isCustomPageUrlBuilt(cp.url)) {
+      const url = await buildCustomPageUrl(cp.url)
+      as.updateCustomPage({ ...cp, url })
+      return
+    }
+
     const url = await rebuildCustomPageUrlPbxToken(cp.url)
     as.updateCustomPage({ ...cp, url })
   }

--- a/src/pages/PageCustomPageView.tsx
+++ b/src/pages/PageCustomPageView.tsx
@@ -56,7 +56,7 @@ export class PageCustomPageView extends Component<{ id: string }> {
       return
     }
 
-    // It should be checked whether the URL is built or not
+    // should check if the url is not built in case pbx reconnect
     if (!isCustomPageUrlBuilt(cp.url)) {
       const url = await buildCustomPageUrl(cp.url)
       as.updateCustomPage({ ...cp, url })


### PR DESCRIPTION
After reconnected to PBX due to PBX server restart or Wifi network reconnected, the custom page is not successfully reloaded