### PR TITLE
Fix issue #879: AudioRecord start recroding get fail on android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 #### 2.14.5
 
 - Fix it should display well custom page when pbx reconnect (issue 885)
-- Fix android it should display PhoneAppli image correctly during 3PCC calls with auto-answer (issue 878)
+- Fix android it should not have oneway voice with auto answer (issue 879)
+- Fix android it should display PhoneAppli image correctly during 3PCC calls with auto answer (issue 878)
 - Fix it should not cut off hang up button in small screen (issue 877, 889)
 - Fix ios it should make call correctly when invoke app immediately from PhoneAppli (issue 876)
 - Fix android it should display well ringing image with PhoneAppli (issue 875)

--- a/src/brekekejs/webrtcclient.js
+++ b/src/brekekejs/webrtcclient.js
@@ -3553,7 +3553,7 @@ if (!Brekeke.WebrtcClient) {
       this._user = ''
       this._videoClientUser = ''
     },
-    _ua_newRTCSession(e) {
+    async _ua_newRTCSession(e) {
       var audio = false
       var data
       var options
@@ -3785,15 +3785,16 @@ if (!Brekeke.WebrtcClient) {
               session.exInfo,
           )
 
-          // answer
+          // wait timeout for audio recording service on android
+          await new Promise(r => setTimeout(r, 500))
 
           // answer
-          setTimeout(() => {
-            session.answeringStarted = true
-            this._doAnswer(
+          session.answeringStarted = true
+          setTimeout(
+            by(this, this._doAnswer, [
               sessionId,
               options,
-              session.rtcSession,
+              data.session,
               null,
               false,
               by(this, this._answerFailed, [
@@ -3804,28 +3805,9 @@ if (!Brekeke.WebrtcClient) {
                   client: 'main',
                 },
               ]),
-            )
-          }, 500)
-
-          // session.answeringStarted = true
-          // setTimeout(
-          //   by(this, this._doAnswer, [
-          //     sessionId,
-          //     options,
-          //     data.session,
-          //     null,
-          //     false,
-          //     by(this, this._answerFailed, [
-          //       {
-          //         sessionId,
-          //         target: null,
-          //         options,
-          //         client: 'main',
-          //       },
-          //     ]),
-          //   ]),
-          //   0,
-          // )
+            ]),
+            0,
+          )
         }
       }
 

--- a/src/brekekejs/webrtcclient.js
+++ b/src/brekekejs/webrtcclient.js
@@ -3786,12 +3786,14 @@ if (!Brekeke.WebrtcClient) {
           )
 
           // answer
-          session.answeringStarted = true
-          setTimeout(
-            by(this, this._doAnswer, [
+
+          // answer
+          setTimeout(() => {
+            session.answeringStarted = true
+            this._doAnswer(
               sessionId,
               options,
-              data.session,
+              session.rtcSession,
               null,
               false,
               by(this, this._answerFailed, [
@@ -3802,9 +3804,28 @@ if (!Brekeke.WebrtcClient) {
                   client: 'main',
                 },
               ]),
-            ]),
-            0,
-          )
+            )
+          }, 500)
+
+          // session.answeringStarted = true
+          // setTimeout(
+          //   by(this, this._doAnswer, [
+          //     sessionId,
+          //     options,
+          //     data.session,
+          //     null,
+          //     false,
+          //     by(this, this._answerFailed, [
+          //       {
+          //         sessionId,
+          //         target: null,
+          //         options,
+          //         client: 'main',
+          //       },
+          //     ]),
+          //   ]),
+          //   0,
+          // )
         }
       }
 


### PR DESCRIPTION
### Precondition:
- PBX 3.16.3.1 - so 180 with SDP is used by default
### Steps:
(1) Login Brekeke phone with account 502 (android 13). And login account 501 in other device.
(2) Switch the 502 to background and lock phone device.
(3) Wait until the 502's UC status become offline, and send below commend to make call from 502 to 501
3pcc command: https://test1.brekeke.vn/pbx/3pcc?tenant=bphone&from=502&to=501&type=2&page=true
=> 502 receives incoming call and is automatically connected. 501 receives incoming call and rings.
(4) 501 answers the call.
=> Actual: The call is connected with one way voice. 501 does not hear voice from 502. And 502 hears voice of 501.