### PR TITLE
Fix issue 862: Answered by <ext> does not show on call history list in killed case

### DIFF
--- a/src/api/sip.ts
+++ b/src/api/sip.ts
@@ -433,12 +433,15 @@ const parseCanceledPnIds = (data?: string) => {
   console.log(`parseCanceledPnIds: msg.length=${msg.length} l=${l}`)
   return msg.split(/\n/g).map(s => {
     const lowers = s.toLowerCase()
-    return lowers.replace(/\s+/g, '').includes(',canceled')
-      ? {
-          pnId: s.match(/(\w+)\W*INVITE/)?.[1],
-          completedElseWhere: lowers.includes('call completed elsewhere'),
-        }
-      : undefined
+    if (!lowers.replace(/\s+/g, '').includes(',canceled')) {
+      return undefined
+    }
+    const match = lowers.match(/Call completed by ([^"]+)/i)
+    return {
+      pnId: s.match(/(\w+)\W*INVITE/)?.[1],
+      completedElseWhere: lowers.includes('call completed elsewhere'),
+      completedBy: match ? match[0] : undefined,
+    }
   })
 }
 

--- a/src/api/sip.ts
+++ b/src/api/sip.ts
@@ -436,11 +436,10 @@ const parseCanceledPnIds = (data?: string) => {
     if (!lowers.replace(/\s+/g, '').includes(',canceled')) {
       return undefined
     }
-    const match = lowers.match(/Call completed by ([^"]+)/i)
     return {
       pnId: s.match(/(\w+)\W*INVITE/)?.[1],
       completedElseWhere: lowers.includes('call completed elsewhere'),
-      completedBy: match ? match[0] : undefined,
+      completedBy: lowers.match(/call completed by ([^"]+)/)?.[0],
     }
   })
 }

--- a/src/stores/addCallHistory.ts
+++ b/src/stores/addCallHistory.ts
@@ -58,7 +58,10 @@ export const getReasonCancelCall = (ms?: {
   }`
 }
 
-export const addCallHistory = async (c: Call | ParsedPn) => {
+export const addCallHistory = async (
+  c: Call | ParsedPn,
+  completedBy?: string,
+) => {
   const isTypeCall = c instanceof Call || 'partyNumber' in c
 
   if (isTypeCall && c.partyNumber === '8') {
@@ -91,7 +94,7 @@ export const addCallHistory = async (c: Call | ParsedPn) => {
   }
   const id = newUuid()
   const created = moment().format('HH:mm - MMM D')
-  const answeredBy = getUserInfoFromReasons(ms)
+  const answeredBy = getUserInfoFromReasons(isTypeCall ? ms : completedBy)
   const reason = getReasonCancelCall(answeredBy)
 
   const info = isTypeCall
@@ -115,6 +118,8 @@ export const addCallHistory = async (c: Call | ParsedPn) => {
         partyName: getPartyName(c.from) || c.displayName || c.from,
         partyNumber: c.from,
         duration: 0,
+        reason,
+        answeredBy,
         // TODO: B killed app, A call B, B reject quickly, then A cancel quickly
         // -> B got cancel event from sip
         isAboutToHangup: false,

--- a/src/stores/callStore2.ts
+++ b/src/stores/callStore2.ts
@@ -686,9 +686,11 @@ export class CallStore {
     {
       setAction = true,
       completedElseWhere,
+      completedBy,
     }: {
       setAction?: boolean
       completedElseWhere?: boolean
+      completedBy?: string
     } = {},
   ) => {
     if (!uuid) {
@@ -707,7 +709,7 @@ export class CallStore {
       !this.calls.some(c => c.callkeepUuid === uuid || c.pnId === pnData.id) &&
       !completedElseWhere
     ) {
-      addCallHistory(pnData)
+      addCallHistory(pnData, completedBy)
     }
     delete this.callkeepMap[uuid]
     RNCallKeep.rejectCall(uuid)
@@ -839,6 +841,7 @@ export class CallStore {
     if (uuid) {
       this.endCallKeep(uuid, {
         completedElseWhere: n.completedElseWhere,
+        completedBy: n.completedBy,
       })
     }
   }

--- a/src/stores/cancelRecentPn.ts
+++ b/src/stores/cancelRecentPn.ts
@@ -6,4 +6,5 @@ export const cancelRecentPn = (n?: CancelRecentPn) =>
 export type CancelRecentPn = {
   pnId?: string
   completedElseWhere?: boolean
+  completedBy?: string
 }


### PR DESCRIPTION
### Steps:
(1) Create a simultaneous ringing ext: 12001, and set "Group Extensions*" as 101, 102
(2) login 102 to brekeke phone and kill it.
(3) Caller makes a call to the simultaneous ringing ext 12001
=> Both 101 and 102 ring.
(4) 101 answers the call.
=> The call is connected, and 102 stop ringing.
(5) Check call history list of Brekeke phone's 102
=> It shows an missed call entry witout message "answered by 101)
Expected: The message "answer by 101" shows under the missed call entry.