### PR TITLE
Fix issue 897: Hide/show call menu can only be touched at points on the left/right side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix it should show "answered by <ext>" in call history (issue 862)
 - Fix ios it should not connect lpc multiple (issue 853, 881)
+- Fix it should be touchable to toggle buttons in video calls (issue 897)
 
 #### 2.14.10
 

--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -166,6 +166,7 @@ const css = StyleSheet.create({
     alignItems: 'center',
     alignSelf: 'stretch',
     marginTop: 10,
+    zIndex: 100,
   },
   viewHangupBtn: {
     marginBottom: 10,
@@ -458,7 +459,7 @@ class PageCallManage extends Component<{
         </View>
         <RnTouchableOpacity
           onPress={this.toggleButtons}
-          style={StyleSheet.absoluteFill}
+          style={[StyleSheet.absoluteFill, { zIndex: 10 }]}
         />
       </>
     )
@@ -531,7 +532,7 @@ class PageCallManage extends Component<{
     return (
       <Container
         onPress={c.localVideoEnabled ? this.toggleButtons : undefined}
-        style={{ marginTop: isHideButtons ? 30 : 0 }}
+        style={{ marginTop: isHideButtons ? 30 : 0, zIndex: 100 }}
       >
         {n > 0 && (
           <FieldButton


### PR DESCRIPTION
### Step:
(1) Make a video call to brekeke phone on IOS (17)
(2) Touch multiple points on the video screen to hide/show the menu
=> Issue: It can only be touched at points on the left/right side
