### PR TITLE
Fix issue 908: Delay auto-answer when killing app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix it should show "answered by <ext>" in call history (issue 862)
 - Fix ios it should not connect lpc multiple (issue 853, 881)
 - Fix it should be touchable to toggle buttons in video calls (issue 897)
+- Fix android it should answer call immediately with x_autoanswer (issue 908)
 
 #### 2.14.10
 

--- a/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
@@ -297,9 +297,9 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
     String callerName = displayName; // redeclare as final to put in nested class
     String avatar = data.get("x_image");
     String avatarSize = data.get("x_image_size");
-    boolean isAutoAnswer = toBoolean(data.get("x_autoanswer"));
-
+    boolean autoAnswer = toBoolean(data.get("x_autoanswer"));
     RNCallKeepModule.registerPhoneAccount(appCtx);
+
     Runnable onShowIncomingCallUi =
         new Runnable() {
           @Override
@@ -322,7 +322,7 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
             i.putExtra("callerName", callerName);
             i.putExtra("avatar", avatar);
             i.putExtra("avatarSize", avatarSize);
-            i.putExtra("autoAnswer", isAutoAnswer);
+            i.putExtra("autoAnswer", autoAnswer);
             c.startActivity(i);
           }
         };
@@ -686,6 +686,7 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
       }
     }
   }
+
   public static boolean toBoolean(String s) {
     if (s != null) {
       return s.equals("on") || s.equals("true") || s.equals("1") || Boolean.parseBoolean(s);

--- a/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
@@ -297,6 +297,8 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
     String callerName = displayName; // redeclare as final to put in nested class
     String avatar = data.get("x_image");
     String avatarSize = data.get("x_image_size");
+    boolean isAutoAnswer = toBoolean(data.get("x_autoanswer"));
+
     RNCallKeepModule.registerPhoneAccount(appCtx);
     Runnable onShowIncomingCallUi =
         new Runnable() {
@@ -320,6 +322,7 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
             i.putExtra("callerName", callerName);
             i.putExtra("avatar", avatar);
             i.putExtra("avatarSize", avatarSize);
+            i.putExtra("autoAnswer", isAutoAnswer);
             c.startActivity(i);
           }
         };
@@ -682,6 +685,12 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
         defaultDialerLauncher.launch(rm.createRequestRoleIntent(RoleManager.ROLE_DIALER));
       }
     }
+  }
+  public static boolean toBoolean(String s) {
+    if (s != null) {
+      return s.equals("on") || s.equals("true") || s.equals("1") || Boolean.parseBoolean(s);
+    }
+    return false;
   }
 
   // perm Ignoring Battery Optimization

--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -99,7 +99,7 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
       answered = false,
       isLarge = false,
       isVideoCall = false,
-      autoAnswer= false;
+      autoAnswer = false;
 
   public JSONObject pbxConfig;
   public JSONObject callConfig;
@@ -126,6 +126,7 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
     avatar = b.getString("avatar");
     avatarSize = b.getString("avatarSize");
     autoAnswer = b.getBoolean("autoAnswer");
+
     if ("rejectCall".equals(BrekekeUtils.userActions.get(uuid))) {
       debug("onCreate rejectCall");
       forceFinish();
@@ -144,9 +145,10 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
 
     setContentView(R.layout.incoming_call_activity);
     BrekekeUtils.activities.add(this);
-    if(!autoAnswer){
+    if (!autoAnswer) {
       BrekekeUtils.staticStartRingtone();
     }
+
     imgAvatarLoadingProgress = new CircularProgressDrawable(this);
     imgAvatarLoadingProgress.setColorSchemeColors(R.color.black, R.color.black, R.color.black);
     imgAvatarLoadingProgress.setCenterRadius(30f);
@@ -248,9 +250,9 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
     txtCallerNameHeader.setText(callerName);
 
     updateLabels();
-    if(autoAnswer){
+    if (autoAnswer) {
       handleClickAnswerCall();
-    }else{
+    } else {
       updateHeader();
     }
     updateCallConfig();

--- a/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/IncomingCallActivity.java
@@ -98,7 +98,8 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
       paused = false,
       answered = false,
       isLarge = false,
-      isVideoCall = false;
+      isVideoCall = false,
+      autoAnswer= false;
 
   public JSONObject pbxConfig;
   public JSONObject callConfig;
@@ -124,7 +125,7 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
     callerName = b.getString("callerName");
     avatar = b.getString("avatar");
     avatarSize = b.getString("avatarSize");
-
+    autoAnswer = b.getBoolean("autoAnswer");
     if ("rejectCall".equals(BrekekeUtils.userActions.get(uuid))) {
       debug("onCreate rejectCall");
       forceFinish();
@@ -143,8 +144,9 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
 
     setContentView(R.layout.incoming_call_activity);
     BrekekeUtils.activities.add(this);
-    BrekekeUtils.staticStartRingtone();
-
+    if(!autoAnswer){
+      BrekekeUtils.staticStartRingtone();
+    }
     imgAvatarLoadingProgress = new CircularProgressDrawable(this);
     imgAvatarLoadingProgress.setColorSchemeColors(R.color.black, R.color.black, R.color.black);
     imgAvatarLoadingProgress.setCenterRadius(30f);
@@ -246,7 +248,11 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
     txtCallerNameHeader.setText(callerName);
 
     updateLabels();
-    updateHeader();
+    if(autoAnswer){
+      handleClickAnswerCall();
+    }else{
+      updateHeader();
+    }
     updateCallConfig();
   }
 


### PR DESCRIPTION
### Step
(1) 102 logins in Android (14) then killing app
(2) Making call with 3PCC like below:
https://test2.brekeke.vn:8443/pbx/3pcc?tenant=nen002&to=116&from=102&page=true&type=2
=> Issue: It was delayed about 2s in the first time. From the 2rd time it was delayed about 1s.