### PR TITLE
Fix issue 793: Custom page is reloaded after reconnecting internet/server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 #### 2.15.1
 
+- Fix it should not reload custom page after reconnect internet/server (issue 793)
 - Fix it should show "answered by <ext>" in call history (issue 862)
 - Fix ios it should not connect lpc multiple (issue 853, 881)
 - Fix it should be touchable to toggle buttons in video calls (issue 897)

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -18,6 +18,7 @@ import { toBoolean } from '../utils/string'
 import {
   addFromNumberNonce,
   hasPbxTokenTobeRepalced,
+  isCustomPageUrlBuilt,
   replaceFromNumberUsingParam,
   replacePbxToken,
   replacePbxTokenUsingSessParam,
@@ -316,7 +317,13 @@ export class PBX extends EventEmitter {
 
     const as = getAuthStore()
     as.pbxConfig = config
-    _parseListCustomPage()
+
+    // The custom page only load at the first time the tab is shown after you log in
+    // even after re-connected it, don't refresh it again
+    const urlCustomPage = as.listCustomPage?.[0]?.url
+    if (!urlCustomPage || !isCustomPageUrlBuilt(urlCustomPage)) {
+      _parseListCustomPage()
+    }
 
     const d = await as.getCurrentDataAsync()
     if (d) {

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -318,8 +318,8 @@ export class PBX extends EventEmitter {
     const as = getAuthStore()
     as.pbxConfig = config
 
-    // The custom page only load at the first time the tab is shown after you log in
-    // even after re-connected it, don't refresh it again
+    // the custom page only load at the first time the tab is shown after you log in
+    //    even after re-connected it, don't refresh it again
     const urlCustomPage = as.listCustomPage?.[0]?.url
     if (!urlCustomPage || !isCustomPageUrlBuilt(urlCustomPage)) {
       _parseListCustomPage()

--- a/src/components/CustomPageWebView.tsx
+++ b/src/components/CustomPageWebView.tsx
@@ -106,6 +106,7 @@ export const CustomPageWebView = ({
       onLoadStart={onLoadStartForLoading}
       onLoadEnd={onLoadEnd}
       onError={onError}
+      cacheEnabled={true}
     />
   )
 }


### PR DESCRIPTION
### Step
(1) Login to brekeke phone
(2) Go to Setting > Custom page tab and change default page by tapping any page link
(3) Disconnect network then recover network
(4) Go to custom page and check reloading custome page

Issue: It reloads custom page to default page 
Expect: Custom page is not reloaded and it keeps page content that changing in step 2