### PR TITLE
Hot fix issue: Can not login brekeke phone app when phoneAppli enabled/disabled on PBX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 2.14.7
+
+- Fix it should be able to open Brekeke Phone with PhoneAppli disabled/enabled on pbx
+
 #### 2.14.6
 
 - Fix ios it should clear badge number when tapping on PN or navigate to call history with PhoneAppli

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -64,8 +64,8 @@ android {
     minSdkVersion rootProject.ext.minSdkVersion
     targetSdkVersion rootProject.ext.targetSdkVersion
     multiDexEnabled true
-    versionCode 214006
-    versionName "2.14.6"
+    versionCode 214007
+    versionName "2.14.7"
   }
 
   signingConfigs {

--- a/ios/BrekekePhone.xcodeproj/project.pbxproj
+++ b/ios/BrekekePhone.xcodeproj/project.pbxproj
@@ -816,7 +816,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift$(inherited)";
-				MARKETING_VERSION = 2.14.6;
+				MARKETING_VERSION = 2.14.7;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brekeke.phonedev.BrekekeLPCExtension;
@@ -858,7 +858,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift$(inherited)";
-				MARKETING_VERSION = 2.14.6;
+				MARKETING_VERSION = 2.14.7;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brekeke.phonedev.BrekekeLPCExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/BrekekePhone/Info.plist
+++ b/ios/BrekekePhone/Info.plist
@@ -23,7 +23,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.14.6</string>
+    <string>2.14.7</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brekekephone",
-  "version": "2.14.6",
+  "version": "2.14.7",
   "private": true,
   "homepage": "./",
   "scripts": {

--- a/src/api/updatePhoneIndex.ts
+++ b/src/api/updatePhoneIndex.ts
@@ -1,8 +1,13 @@
+import { Platform } from 'react-native'
+
 import { accountStore } from '../stores/accountStore'
 import { getAuthStore } from '../stores/authStore'
 import { intl, intlDebug } from '../stores/intl'
 import { Nav } from '../stores/Nav'
 import { RnAlert } from '../stores/RnAlert'
+import { RnStacker } from '../stores/RnStacker'
+import { openLinkSafely, urls } from '../utils/deeplink'
+import { PushNotification } from '../utils/PushNotification'
 import { pbx } from './pbx'
 
 export const updatePhoneIndex = async (
@@ -32,9 +37,20 @@ export const updatePhoneIndex = async (
   if (p.id === as.getCurrentAccount()?.id) {
     as.userExtensionProperties = extProps
     const d = await as.getCurrentDataAsync()
+    const paEnabled = extProps.phoneappli
     if (d) {
-      d.phoneappliEnabled = extProps.phoneappli
+      d.phoneappliEnabled = paEnabled
       accountStore.updateAccountData(d)
+    }
+    // Open Phone Appli app when phoneappli.enable is true and on PageCallRecents
+    const s = RnStacker.stacks[RnStacker.stacks.length - 1]
+    if (paEnabled && s.name === 'PageCallRecents') {
+      Nav().customPageIndex = Nav().goToPageCallKeypad
+      Nav().goToPageCallKeypad()
+      if (Platform.OS === 'ios') {
+        PushNotification.resetBadgeNumber()
+      }
+      openLinkSafely(urls.phoneappli.HISTORY_CALLED)
     }
   }
 

--- a/src/stores/authStore2.ts
+++ b/src/stores/authStore2.ts
@@ -145,6 +145,27 @@ export class AuthStore {
       })
       return true
     }
+
+    // handle replace navSubMenus when login to make sure app will not auto open Phone Appli app
+    if (
+      a.navSubMenus?.length &&
+      a.navSubMenus.some(item => item === 'recents' || item === 'phonebook')
+    ) {
+      const updatedNavSubMenus = a.navSubMenus.map(item => {
+        if (item === 'recents') {
+          return 'keypad'
+        } else if (item === 'phonebook') {
+          return 'users'
+        } else {
+          return item
+        }
+      })
+      await accountStore.upsertAccount({
+        id: a.id,
+        navSubMenus: updatedNavSubMenus,
+      })
+    }
+
     this.signedInId = a.id
     BrekekeUtils.setPhoneappliEnabled(!!this.phoneappliEnabled())
     if (!autoSignIn) {

--- a/src/utils/PushNotification-parse.ts
+++ b/src/utils/PushNotification-parse.ts
@@ -238,7 +238,8 @@ export const parse = async (
     console.log(
       'SIP PN debug: PushNotification-parse: local notification missed call',
     )
-    if (as.phoneappliEnabled()) {
+
+    if (as.userExtensionProperties && as.phoneappliEnabled()) {
       navIndex('goToPageCallKeypad')
       if (Platform.OS === 'ios') {
         PushNotification.resetBadgeNumber()


### PR DESCRIPTION
###【Procedure】
1. With PHONE APPLI linked, tap on the top right of BrekekePhone's [Current Account] screen to log out.
2. Log in to the PBX management screen using a browser and set the BrekekePhone user's [PHONE APPLI PEOPLE Settings] > [Cooperation] to "No".
3. Log in with BrekekePhone and display the [History] screen.
4. Tap the settings icon at the bottom right of the screen, then tap... at the top right of the [Current account] screen to log out.
5. Log in to the PBX management screen using a browser and set the BrekekePhone user's [PHONE APPLI PEOPLE Settings] > [Cooperation] to "Yes".
6. Log in with BrekekePhone.
⇒ Actual: The [Recent] tab is displayed. I also think this behavior is strange. (NG)

**Expected**: Login Brekeke phone and not showing a Recent tab - in order to not let it loads PhoneAppli.
If manually tapping on the Recent tab, it load PhoneAppli well

7. Slide BrekekePhone from the app list to close the BrekekePhone app.
8. Launch BrekekePhone.
⇒ Actual: PHONE APPLI app starts. After that, when I try to log in using BrekekePhone, I cannot log in. (NG)

**Expected**: login Brekeke phone well