### PR TITLE
Fix issue for 2.14.x: Layout has been cut off on call transfer page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix ios it should not connect lpc multiple (issue 853, 881)
 - Fix it should be touchable to toggle buttons in video calls (issue 897)
 - Fix android it should answer call immediately with x_autoanswer (issue 908)
+- Fix web browser it should display well in page transfer attend
 
 #### 2.14.10
 

--- a/src/pages/PageCallTransferAttend.tsx
+++ b/src/pages/PageCallTransferAttend.tsx
@@ -38,6 +38,7 @@ export const css = StyleSheet.create({
     marginBottom: 30,
     ...Platform.select({
       web: {
+        // browser justify content center doesnt work as react native
         maxWidth: 400,
         minWidth: 250,
         justifyContent: 'space-between',

--- a/src/pages/PageCallTransferAttend.tsx
+++ b/src/pages/PageCallTransferAttend.tsx
@@ -1,6 +1,6 @@
 import { observer } from 'mobx-react'
 import { Component } from 'react'
-import { StyleSheet, View } from 'react-native'
+import { Platform, StyleSheet, View } from 'react-native'
 
 import { pbx } from '../api/pbx'
 import { sip } from '../api/sip'
@@ -23,15 +23,29 @@ export const css = StyleSheet.create({
   Outer: {
     alignItems: 'center',
     backgroundColor: 'white',
+    ...Platform.select({
+      web: {
+        width: '100%',
+      },
+    }),
   },
   Inner: {
     width: '70%',
     flexDirection: 'row',
-    justifyContent: 'center',
     alignItems: 'center',
     alignSelf: 'center',
     alignContent: 'center',
     marginBottom: 30,
+    ...Platform.select({
+      web: {
+        maxWidth: 400,
+        minWidth: 250,
+        justifyContent: 'space-between',
+      },
+      default: {
+        justifyContent: 'center',
+      },
+    }),
   },
   Inner__info: {
     maxWidth: 'auto',


### PR DESCRIPTION
Layout has been cut off on call transfer page
![image](https://github.com/user-attachments/assets/3cff9f2d-17f6-4f07-b662-d4da77a11a6d)
