### PR TITLE
Fix bug 934: [iOS] Can not load video when turning it on from a voice call.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fix ios it should not connect lpc multiple (issue 853, 881)
 - Fix it should be touchable to toggle buttons in video calls (issue 897)
 - Fix android it should answer call immediately with x_autoanswer (issue 908)
-- Fix web browser it should display well in page transfer attend
+- Fix it should load video when turning it on from a voice call (issue 934)
 
 #### 2.14.10
 

--- a/src/api/sip.ts
+++ b/src/api/sip.ts
@@ -230,7 +230,7 @@ export class SIP extends EventEmitter {
       if (!ev) {
         return
       }
-      console.error('thangnt::sessionStatusChanged', ev)
+
       if (ev.sessionStatus === 'terminated') {
         this.emit('session-stopped', ev)
         return
@@ -257,7 +257,6 @@ export class SIP extends EventEmitter {
       if (!ev) {
         return
       }
-      console.error('thangnt::videoClientSessionEnded', ev)
 
       this.emit('session-updated', {
         id: ev.sessionId,
@@ -265,8 +264,6 @@ export class SIP extends EventEmitter {
         remoteVideoEnabled: false,
         remoteVideoStreamObject: null,
       })
-      // this.disableVideo(ev.sessionId)
-      // this.enableVideo(ev.sessionId)
     })
 
     phone.addEventListener('rtcErrorOccurred', ev => {

--- a/src/brekekejs/index.d.ts
+++ b/src/brekekejs/index.d.ts
@@ -455,6 +455,7 @@ export type SipEventMap = {
   phoneStatusChanged: PhoneStatusChangedEvent
   sessionCreated: Session
   sessionStatusChanged: Session
+  remoteUserOptionsChanged: Session
   videoClientSessionCreated: VideoSession
   videoClientSessionEnded: VideoSession
   rtcErrorOccurred: Error


### PR DESCRIPTION
Case1:
(1) iOS makes a voice call
(2) Callee answers the call
(3) Caller (iOS) turns video on then Callee turn it on.
 => Result: Video can not be loaded on Caller, and it show a black loading screen.

Case2:
(1) iOS makes a video call
(2) Callee receives incoming call and answer it.
(3) While video is loading on the caller (iOS), the callee tries to turn video off then on after a few seconds (around 3 seconds).