### PR TITLE
Fix bug 887: "Answered by <ext>" is not shown when users of group answer simultaneously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 - Upgrade android target sdk 34 to update with Google policy
 - Implement push notification timestamp
 - Fix it should not reload custom page after reconnect internet/server (issue 793)
-- Fix it should show "answered by <ext>" in call history (issue 862)
 - Fix ios it should not connect lpc multiple (issue 853, 881)
+- Fix it should show "answered by <ext>" in call history (issue 862)
+- Fix it should show "answered by <ext>" when users of group answer simultaneously (issue 887)
 - Fix ios it should keep the call when screen is off by proximity sensor for 90 seconds (issue 891)
 - Fix it should be touchable to toggle buttons in video calls (issue 897)
 - Fix android it should answer call immediately with x_autoanswer (issue 908)

--- a/src/stores/addCallHistory.ts
+++ b/src/stores/addCallHistory.ts
@@ -32,8 +32,8 @@ export const getUserInfoFromReasons = (reason?: string | false) => {
   if (!reason) {
     return
   }
-  // When *** has ( and ),  the string in those parentheses is the phone number.
-  // When *** does not have ( and ), then the entiere string is the phone number.
+  // when *** has ( and ),  the string in those parentheses is the phone number.
+  // when *** does not have ( and ), then the entiere string is the phone number.
   let m = reason.match(/call completed by (.*?)\((.*?)\)/i)
   if (!m) {
     m = reason.match(/call completed by (.+)/i)
@@ -109,6 +109,7 @@ export const addCallHistory = async (
         isAboutToHangup: c.isAboutToHangup,
         reason,
         answeredBy,
+        completedBy,
       }
     : {
         id,
@@ -120,6 +121,7 @@ export const addCallHistory = async (
         duration: 0,
         reason,
         answeredBy,
+        completedBy,
         // TODO: B killed app, A call B, B reject quickly, then A cancel quickly
         // -> B got cancel event from sip
         isAboutToHangup: false,
@@ -165,6 +167,7 @@ export type CallHistoryInfo = {
   isAboutToHangup: boolean
   reason?: string
   answeredBy?: { name: string; phoneNumber: string }
+  completedBy?: string
 }
 
 const addToCallLog = async (c: CallHistoryInfo) => {
@@ -227,9 +230,11 @@ const presentNotification = async (c: CallHistoryInfo) => {
   if (Platform.OS === 'web') {
     return
   }
-  // If two users answer a call at the same time, the system will automatically end the call for the second user to join.
-  // The second user will receive a reason: "Call completed by ..."
-  if ((c.answered && !c.reason) || !c.incoming || c.isAboutToHangup) {
+  // if two users answer a call at the same time, the system will automatically end the call for the second user to join
+  // the second user will receive a reason: "Call completed by ..."
+  // --> c.answered = true, c.completedBy = "..." -> show noti
+  const shouldPresent = c.answered && c.completedBy
+  if ((c.answered || !c.incoming || c.isAboutToHangup) && !shouldPresent) {
     return
   }
   const title = intl`Missed call`

--- a/src/stores/addCallHistory.ts
+++ b/src/stores/addCallHistory.ts
@@ -222,7 +222,9 @@ const presentNotification = async (c: CallHistoryInfo) => {
   if (Platform.OS === 'web') {
     return
   }
-  if (c.answered || !c.incoming || c.isAboutToHangup) {
+  // If two users answer a call at the same time, the system will automatically end the call for the second user to join.
+  // The second user will receive a reason: "Call completed by ..."
+  if ((c.answered && !c.reason) || !c.incoming || c.isAboutToHangup) {
     return
   }
   const title = intl`Missed call`


### PR DESCRIPTION
Prepare Ringing group ext as below:
 Ext: 10003
 Group Extensions*: 102,104
 (1) Login 102 to phone A, 104 to phone B
 (2) Make call to group 10003
 => 102, 104 ring
 (3) Both 102, 104 pick up call simultaneously but 102 quiker
 (4) Check missed call notify and history in Recents list of 102 and 104
 => 104 not show notify popup but Recents list of 102 and 104 show missed call without "Answered by <ext> ..." in user 104 -> NG