### PR TITLE
Fix bug 918: Call screen always keep at 00:00 time (connecting) after manually allow Notification permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix ios it should keep the call when screen is off by proximity sensor for 90 seconds (issue 891)
 - Fix it should be touchable to toggle buttons in video calls (issue 897)
 - Fix android it should answer call immediately with x_autoanswer (issue 908)
+- Fix it should display call duration correctly after manually allow Notification permissions (issue 918)
 - Fix it should load video when turning it on from a voice call (issue 934)
 
 #### 2.14.10

--- a/src/utils/PushNotification.android.ts
+++ b/src/utils/PushNotification.android.ts
@@ -72,11 +72,6 @@ export const PushNotification = {
         onFcmToken(e.deviceToken)
       })
 
-      // we should be able to get fcm token without permission request
-      if (!hasPermissions) {
-        throw new Error(intl`Don't have Permissions`)
-      }
-
       events.registerRemoteNotificationsRegistrationFailed(
         (e: RegistrationError) => {
           console.error('Failed to register remote notification', e)
@@ -144,6 +139,11 @@ export const PushNotification = {
         const payload = n?.payload?.payload || n?.payload
         onNotification(payload, initApp, true)
       })
+
+      // we should be able to get fcm token without permission request
+      if (!hasPermissions) {
+        throw new Error(intl`Don't have Permissions`)
+      }
     } catch (err) {
       console.error(
         'PushNotification register error: Failed to initialize push notification',


### PR DESCRIPTION
Case 1:
(1) Install app and allow all permissions except Notifications
(2) Tap Login button
=> It shown Notifications permissions
(3) Tap OK and allow Notifications in device setting
(4) Tap login and then made a call to Android
(5) Android answered call
=> Issue: The call is connected but call sreen always kept at 00:00

Case 2:
(1) Install brekeke phone and allow all permissions and enable PN then login
(2) Kill app
(3) Go to setting of phone and block Notifications of brekeke phone
(4) Open again app 
=> It show required Notifications permissions
(5) Tap OK button and allow Notifications
(6) Back again app and make a call to brekeke phone
(7) Pick up call
=> The call is connected but it always keeps at 00:00 time on call sreen (NG)
