### PR TITLE
Fix issue 909: It shows a "Connecting..." message and cannot answer incoming PN call well after making call while being reconnecting due to PBX restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix ios it should keep the call when screen is off by proximity sensor for 90 seconds (issue 891)
 - Fix it should be touchable to toggle buttons in video calls (issue 897)
 - Fix android it should answer call immediately with x_autoanswer (issue 908)
+- Fix it should answer incoming PN call after reconnecting due to PBX restart (issue 909)
 - Fix it should display call duration correctly after manually allow Notification permissions (issue 918)
 - Fix it should load video when turning it on from a voice call (issue 934)
 - Fix it should play RBT when make call without SDP (issue 964)

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,7 +12,7 @@ import { contactStore, getPartyName } from '../stores/contactStore'
 import { intl } from '../stores/intl'
 import { sipErrorEmitter } from '../stores/sipErrorEmitter'
 import { userStore } from '../stores/userStore'
-import { resetCallActionMapAndroidProcessedPn } from '../utils/PushNotification-parse'
+import { resetProcessedPn } from '../utils/PushNotification-parse'
 import { toBoolean } from '../utils/string'
 import { pbx } from './pbx'
 import { sip } from './sip'
@@ -142,7 +142,7 @@ class Api {
   onSIPConnectionStopped = (e: { reason: string; response: string }) => {
     const s = getAuthStore()
     console.log('SIP PN debug: set sipState failure stopped')
-    resetCallActionMapAndroidProcessedPn()
+    resetProcessedPn()
     s.sipState = 'failure'
     s.sipTotalFailure += 1
     if (s.sipTotalFailure > 3) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,6 +12,7 @@ import { contactStore, getPartyName } from '../stores/contactStore'
 import { intl } from '../stores/intl'
 import { sipErrorEmitter } from '../stores/sipErrorEmitter'
 import { userStore } from '../stores/userStore'
+import { resetCallActionMapAndroidProcessedPn } from '../utils/PushNotification-parse'
 import { toBoolean } from '../utils/string'
 import { pbx } from './pbx'
 import { sip } from './sip'
@@ -141,6 +142,7 @@ class Api {
   onSIPConnectionStopped = (e: { reason: string; response: string }) => {
     const s = getAuthStore()
     console.log('SIP PN debug: set sipState failure stopped')
+    resetCallActionMapAndroidProcessedPn()
     s.sipState = 'failure'
     s.sipTotalFailure += 1
     if (s.sipTotalFailure > 3) {

--- a/src/api/sip.ts
+++ b/src/api/sip.ts
@@ -14,6 +14,7 @@ import { getCallStore } from '../stores/callStore'
 import { cancelRecentPn } from '../stores/cancelRecentPn'
 import { chatStore } from '../stores/chatStore'
 import type { ParsedPn } from '../utils/PushNotification-parse'
+import { resetProcessedPn } from '../utils/PushNotification-parse'
 import { toBoolean } from '../utils/string'
 import { waitTimeout } from '../utils/waitTimeout'
 import { getCameraSourceIds } from './getCameraSourceId'
@@ -277,6 +278,7 @@ export class SIP extends EventEmitter {
 
   connect = async (o: SipLoginOption, a: AccountUnique) => {
     console.log('SIP PN debug: call sip.stopWebRTC in sip.connect')
+    resetProcessedPn()
     this.phone?._removeEventListenerPhoneStatusChange?.()
     this.stopWebRTC()
     const phone = await this.init(o)

--- a/src/stores/callStore2.ts
+++ b/src/stores/callStore2.ts
@@ -472,6 +472,11 @@ export class CallStore {
   }
   private callkeepUuidPending = ''
   startCall: MakeCallFn = async (number: string, ...args) => {
+    // Make sure sip is ready before make call
+    if (getAuthStore().sipState !== 'success') {
+      return
+    }
+
     if (!(await permForCall())) {
       return
     }

--- a/src/utils/PushNotification-parse.ts
+++ b/src/utils/PushNotification-parse.ts
@@ -185,10 +185,13 @@ export const parseNotificationData = (raw?: object) => {
 const isNoU = (v: unknown) => v === null || v === undefined
 let androidAlreadyProccessedPn: { [k: string]: boolean } = {}
 
+// after pbx server reset, call id (number) on the server side will be reset to 1, 2, 3...
+// if the cache contain those ids previously, the new calls will be rejected
 export const resetProcessedPn = () => {
   getCallStore().callkeepActionMap = {}
   androidAlreadyProccessedPn = {}
 }
+
 export const parse = async (
   raw?: { [k: string]: unknown },
   isLocal = false,

--- a/src/utils/PushNotification-parse.ts
+++ b/src/utils/PushNotification-parse.ts
@@ -185,7 +185,7 @@ export const parseNotificationData = (raw?: object) => {
 const isNoU = (v: unknown) => v === null || v === undefined
 let androidAlreadyProccessedPn: { [k: string]: boolean } = {}
 
-export const resetCallActionMapAndroidProcessedPn = () => {
+export const resetProcessedPn = () => {
   getCallStore().callkeepActionMap = {}
   androidAlreadyProccessedPn = {}
 }
@@ -305,7 +305,7 @@ export const parse = async (
   // also we forked fcm to insert callkeepUuid there as well
   // then this should not happen
   if (!n.callkeepUuid) {
-    console.log(
+    console.error(
       `SIP PN debug: PushNotification-parse got pnId=${n.id} without callkeepUuid`,
     )
     return

--- a/src/utils/PushNotification-parse.ts
+++ b/src/utils/PushNotification-parse.ts
@@ -183,8 +183,12 @@ export const parseNotificationData = (raw?: object) => {
 }
 
 const isNoU = (v: unknown) => v === null || v === undefined
-const androidAlreadyProccessedPn: { [k: string]: boolean } = {}
+let androidAlreadyProccessedPn: { [k: string]: boolean } = {}
 
+export const resetCallActionMapAndroidProcessedPn = () => {
+  getCallStore().callkeepActionMap = {}
+  androidAlreadyProccessedPn = {}
+}
 export const parse = async (
   raw?: { [k: string]: unknown },
   isLocal = false,
@@ -304,6 +308,7 @@ export const parse = async (
     console.log(
       `SIP PN debug: PushNotification-parse got pnId=${n.id} without callkeepUuid`,
     )
+    return
   }
   const cs = getCallStore()
 


### PR DESCRIPTION
(1) Login Brekeke phone, and restart PBX.
(2) When it shows "Connecting to PBX..." message, try to make call from the brekeke phone.
=> Call is not successful and disconnected after that.
But, screen is stuck at a "Connecting..." message.
*** It occurs both iOS and Android.
(3) After PBX is restated and up.
=> Brekeke phone is auto reconnected.
(4) Try to make a PN call to the Brekeke phone.
=> Call screen shows for the incoming PN call.
(5) Answer the call.
=> The call is not connected. 
-For iOS: An incoming PN call disappears right after it arrives.
It is an existing issue for iOS
- For Android: a call screen shows as "Connecting....". 
And it seem to be broken issue as not easily happen on 2.13.7
