### PR TITLE
Fix issue 866: UC connection failed

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -56,7 +56,8 @@ class Api {
     const s = getAuthStore()
     s.pbxState = 'success'
     s.pbxTotalFailure = 0
-    authSIP.authWithCheck()
+    // Should make sure reaction will be exist
+    authSIP.auth()
     await waitSip()
     await pbx.getConfig()
     const ca = s.getCurrentAccount()


### PR DESCRIPTION
Reproduction steps:
(1) Login brekeke phone 
(2) Restart PBX server
(3) When it shows a connection message on top of Brekeke phone, lock the phone device.
(4) After PBX server is up for a while (around 1 minute), unlock the phone device.
=>  Error message "connection failed" occurs, and the brekeke phone cannot reconnect after that.
 It shows "Sip connection failed"

Try to select reconnect to Server, but it does not help. The error is only removed after close/reopen the brekeke phone.