### PR TITLE
Issue #902: [IOS] When making call with 3pcc & auto answer, the call is connected without voice if callee (to field) answers first.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix it should show "answered by <ext>" when users of group answer simultaneously (issue 887)
 - Fix ios it should keep the call when screen is off by proximity sensor for 90 seconds (issue 891)
 - Fix it should be touchable to toggle buttons in video calls (issue 897)
+- Fix ios remove all auto answer code because of not supported (issue 902)
 - Fix android it should answer call immediately with x_autoanswer (issue 908)
 - Fix it should answer incoming PN call after reconnecting due to PBX restart (issue 909)
 - Fix it should display call duration correctly after manually allow Notification permissions (issue 918)

--- a/src/api/sip.ts
+++ b/src/api/sip.ts
@@ -32,10 +32,7 @@ const alreadyRemovePnTokenViaSip: { [k: string]: boolean } = {}
 export const checkAndRemovePnTokenViaSip = async (n: ParsedPn) => {
   const acc = await accountStore.findByPn(n)
   const k = n.id || jsonStableStringify(n)
-  console.log(`SIP PN debug: checkAndRemovePnTokenViaSip  accUserName::${acc?.pbxUsername} alreadyRemovePnTokenViaSip[${k}]::${alreadyRemovePnTokenViaSip[k]}
-    autoAnswer=${n.sipPn.autoAnswer} isCall=${n.isCall} callkeepUuid=${n.callkeepUuid} `)
-  const ignoreAutoAnswerIos = Platform.OS === 'ios' && n.sipPn.autoAnswer
-  if (!alreadyRemovePnTokenViaSip[k] && (ignoreAutoAnswerIos || !acc)) {
+  if (!alreadyRemovePnTokenViaSip[k] && !acc) {
     alreadyRemovePnTokenViaSip[k] = true
     removePnTokenViaSip(n)
   }
@@ -46,10 +43,6 @@ const removePnTokenViaSip = async (n: ParsedPn) => {
   const s = getCallStore()
   if (n.callkeepUuid) {
     s.onCallKeepEndCall(n.callkeepUuid)
-  }
-  if (n.sipPn.autoAnswer) {
-    console.log('checkAndRemovePnTokenViaSip debug: remove autoAnswer call')
-    return
   }
   if (!n.sipPn.sipAuth) {
     console.log(

--- a/src/api/sip.ts
+++ b/src/api/sip.ts
@@ -30,7 +30,10 @@ const alreadyRemovePnTokenViaSip: { [k: string]: boolean } = {}
 export const checkAndRemovePnTokenViaSip = async (n: ParsedPn) => {
   const acc = await accountStore.findByPn(n)
   const k = n.id || jsonStableStringify(n)
-  if (!alreadyRemovePnTokenViaSip[k] && !acc) {
+  console.log(`SIP PN debug: checkAndRemovePnTokenViaSip  accUserName::${acc?.pbxUsername} alreadyRemovePnTokenViaSip[${k}]::${alreadyRemovePnTokenViaSip[k]}
+    autoAnswer=${n.sipPn.autoAnswer} isCall=${n.isCall} callkeepUuid=${n.callkeepUuid} `)
+  const ignoreAutoAnswerIos = Platform.OS === 'ios' && n.sipPn.autoAnswer
+  if (!alreadyRemovePnTokenViaSip[k] && (ignoreAutoAnswerIos || !acc)) {
     alreadyRemovePnTokenViaSip[k] = true
     removePnTokenViaSip(n)
   }
@@ -41,6 +44,10 @@ const removePnTokenViaSip = async (n: ParsedPn) => {
   const s = getCallStore()
   if (n.callkeepUuid) {
     s.onCallKeepEndCall(n.callkeepUuid)
+  }
+  if (n.sipPn.autoAnswer) {
+    console.log('checkAndRemovePnTokenViaSip debug: remove autoAnswer call')
+    return
   }
   if (!n.sipPn.sipAuth) {
     console.log(

--- a/src/stores/callStore2.ts
+++ b/src/stores/callStore2.ts
@@ -71,12 +71,12 @@ export class CallStore {
       if (RnAppState.foregroundOnce && AppState.currentState !== 'active') {
         RNCallKeep.backToForeground()
       }
-      BackgroundTimer.setTimeout(() => {
-        if (Platform.OS === 'ios') {
-          RNCallKeep.answerIncomingCall(uuid)
-        }
-        BrekekeUtils.onCallKeepAction(uuid, 'answerCall')
-      }, 2000)
+      // on android already answer in native java activity
+      // on ios, QA suggest to reject the call?
+      // TODO
+      if (Platform.OS === 'ios') {
+        // TODO
+      }
     }
     checkAndRemovePnTokenViaSip(n)
     // find the current incoming call which is not callkeep


### PR DESCRIPTION
 ### STEP
 Pre: Set SDP 18x (Early media)
(1) Login user 901 to brekeke phone on IOS (17) and 903 anywhere
(2) 901 run forground and lock phone
(3) Make call by 3PCC with URL:
https://dev01.brekeke.com:8443/pbx/3pcc?tenant=tuc&to=903&from=901&type=2&page=true&phone=4
=> Actual: 
PBX makes a call to 901.
Due to auto answer issue (Issue #901), although the device screen may be looked like the 901 didn't pick up a call, but actually 901 answered the call according to the SIP protocol. (sent 200 OK to PBX).
Then, the PBX make a call to 903, and 903 is ringing.

(4) 903 (callee) picks up call then 901 picks up call
=> The call is connected but no voice in both 901 and 903 -> NG
### Solution
We do not support "auto answer call function" for ios. Brekeke phone will reject call when receive  PN auto_answer call on iOS.