### PR TITLE
Fix issue 980: It shows a call screen with an Answer button as normally in foreground when making call with 3pcc & auto answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### 2.15.3
 
 - Fix it should reconnect pbx on notification if it has been in background for more than 10s
+- Fix ios auto answer 3pcc (issue 980)
 - Embed:
   - Fix it should emit call_update correctly
 

--- a/src/stores/callStore2.ts
+++ b/src/stores/callStore2.ts
@@ -81,7 +81,6 @@ export class CallStore {
       // on ios, QA suggest to reject the call?
       // TODO
       if (Platform.OS === 'ios') {
-        // Handling the case where a PN for an incoming call is received after the answer call is invoked
         BackgroundTimer.setTimeout(() => {
           RNCallKeep.answerIncomingCall(uuid)
         }, 2000)

--- a/src/stores/callStore2.ts
+++ b/src/stores/callStore2.ts
@@ -77,7 +77,10 @@ export class CallStore {
       // on ios, QA suggest to reject the call?
       // TODO
       if (Platform.OS === 'ios') {
-        // TODO
+        // Handling the case where a PN for an incoming call is received after the answer call is invoked
+        BackgroundTimer.setTimeout(() => {
+          RNCallKeep.answerIncomingCall(uuid)
+        }, 2000)
       }
     }
     checkAndRemovePnTokenViaSip(n)


### PR DESCRIPTION
### Step
(1) Login user 307 to brekeke phone on IOS (17) and 308 (Android) 
(2) 307 runs background
(3) Make call by 3PCC with URL:
https://test2.brekeke.vn:8443/pbx/3pcc?tenant=nen002&to=308&from=307&type=2&page=true&phone=4
=> 307 and 308 ring
(4) 307 answers then 308 answer
=> The call is connected well
(5) Switch 207 to forground and repeat step 3, 4 multi times 
=> Issue: it shows a call screen with an Answer button as normally in forground