### PR TITLE
Fix issue #990, #991, #992

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Update line selection: label for no line, remove duplicated
 - Implement webphone.http.useragent.product to inject user agent for webview avatar
 - Fix ios auto answer 3pcc (issue 980)
+- Fix improvements for notify_pal (issue 990, 991, 992)
 - Embed:
   - Fix it should emit call_update correctly
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -87,6 +87,12 @@ class Api {
     if (s.isSignInByNotification) {
       return
     }
+    if (s.pbxLoginFromAnotherPlace) {
+      console.log(
+        'pbxLoginFromAnotherPlace debug: stop sync pn token when pbx login from another place',
+      )
+      return
+    }
     SyncPnToken()
       .sync(ca)
       .then(() => SyncPnToken().syncForAllAccounts())

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -16,7 +16,6 @@ import { accountStore } from '../stores/accountStore'
 import { authPBX } from '../stores/AuthPBX'
 import { authSIP } from '../stores/AuthSIP'
 import { getAuthStore, waitPbx } from '../stores/authStore'
-import { authUC } from '../stores/AuthUC'
 import { getCallStore } from '../stores/callStore'
 import type { PbxUser, Phonebook } from '../stores/contactStore'
 import { intl } from '../stores/intl'
@@ -604,7 +603,6 @@ export class PBX extends EventEmitter {
     if (!this.client) {
       return false
     }
-    console.log('thangnt::holdTalker::client', !!this.client)
     await this.client.call_pal('hold', {
       tenant,
       tid: talker,

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -36,6 +36,7 @@ import {
 import { parseCallParams, parsePalParams } from './parseParamsWithPrefix'
 import type { PnParams, PnParamsNew } from './pnConfig'
 import { PnCommand, PnServiceId } from './pnConfig'
+import { sip } from './sip'
 import { SyncPnToken } from './syncPnToken'
 
 export class PBX extends EventEmitter {
@@ -297,7 +298,7 @@ export class PBX extends EventEmitter {
     }
     if (e.code === 1 && e.message === 'ANOTHER_LOGIN') {
       getAuthStore().pbxLoginFromAnotherPlace = true
-      if (!getCallStore().calls.length) {
+      if (!getCallStore().calls.length && !sip.phone?.getSessionCount()) {
         console.log(
           'pbxLoginFromAnotherPlace debug:  No call is in progress, disconnect SIP and PBX.',
         )
@@ -312,7 +313,7 @@ export class PBX extends EventEmitter {
         authSIP.dispose()
         authPBX.dispose()
       }
-      // Wait for the last device to complete syncing the token before allowing the current device to interact.
+      // wait for the last device to complete syncing the token before allowing the current device to interact
       await waitTimeout(2500)
       getAuthStore().showMsgPbxLoginFromAnotherPlace = true
     }
@@ -618,7 +619,6 @@ export class PBX extends EventEmitter {
     if (!this.client) {
       return false
     }
-
     await this.client.call_pal('unhold', {
       tenant,
       tid: talker,

--- a/src/api/syncPnToken2.ts
+++ b/src/api/syncPnToken2.ts
@@ -3,6 +3,7 @@ import { getCurrentWifiSSID } from 'react-native-wifi-reborn'
 
 import type { Account } from '../stores/accountStore'
 import { accountStore } from '../stores/accountStore'
+import { getAuthStore } from '../stores/authStore'
 import { compareSemVer } from '../stores/debugStore'
 import { PushNotification } from '../utils/PushNotification'
 import { BrekekeUtils } from '../utils/RnNativeModules'
@@ -30,7 +31,8 @@ const syncPnTokenWithoutCatch = async (
     return
   }
 
-  const pnEnabled = p.pushNotificationEnabled
+  const pnEnabled =
+    !getAuthStore().pbxLoginFromAnotherPlace && p.pushNotificationEnabled
   console.log(
     `PN sync debug: trying to turn ${pnEnabled ? 'on' : 'off'} PN for account ${
       p.pbxUsername

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -265,6 +265,7 @@ export const App = observer(() => {
     ucConnectingOrFailure,
     ucLoginFromAnotherPlace,
     pbxLoginFromAnotherPlace,
+    showMsgPbxLoginFromAnotherPlace,
     signedInId,
     resetFailureStateIncludePbxOrUc,
   } = getAuthStore()
@@ -278,15 +279,17 @@ export const App = observer(() => {
         : ''
   const isFailure = isConnFailure()
   const connMessage =
-    isFailure && pbxLoginFromAnotherPlace
-      ? intl`Logged in from another location as the same phone`
-      : isFailure && ucLoginFromAnotherPlace
-        ? intl`UC signed in from another location`
-        : !serviceConnectingOrFailure
-          ? ''
-          : isFailure
-            ? intl`${serviceConnectingOrFailure} connection failed`
-            : intl`Connecting to ${serviceConnectingOrFailure}...`
+    pbxLoginFromAnotherPlace && !showMsgPbxLoginFromAnotherPlace
+      ? ''
+      : isFailure && showMsgPbxLoginFromAnotherPlace
+        ? intl`Logged in from another location as the same phone`
+        : isFailure && ucLoginFromAnotherPlace
+          ? intl`UC signed in from another location`
+          : !serviceConnectingOrFailure
+            ? ''
+            : isFailure
+              ? intl`${serviceConnectingOrFailure} connection failed`
+              : intl`Connecting to ${serviceConnectingOrFailure}...`
 
   const onPressConnMessage = isFailure
     ? resetFailureStateIncludePbxOrUc

--- a/src/stores/addCallHistory.ts
+++ b/src/stores/addCallHistory.ts
@@ -11,6 +11,8 @@ import type { ParsedPn } from '../utils/PushNotification-parse'
 import { BrekekeUtils, CallLogType } from '../utils/RnNativeModules'
 import { waitTimeout } from '../utils/waitTimeout'
 import { accountStore } from './accountStore'
+import { authPBX } from './AuthPBX'
+import { authSIP } from './AuthSIP'
 import { getAuthStore } from './authStore'
 import { Call } from './Call'
 import { getCallStore } from './callStore'
@@ -82,6 +84,14 @@ export const addCallHistory = async (
       'checkAndRemovePnTokenViaSip debug: do not add history account not exist',
     )
     return
+  }
+
+  if (getAuthStore().pbxLoginFromAnotherPlace) {
+    console.log(
+      'pbxLoginFromAnotherPlace debug: dispose authSIP and authPBX after call finished',
+    )
+    authSIP.dispose()
+    authPBX.dispose()
   }
 
   const ms =

--- a/src/stores/authStore2.ts
+++ b/src/stores/authStore2.ts
@@ -158,7 +158,6 @@ export class AuthStore {
       return
     }
     const userAgent = await getUserAgent(a)
-    // Update for native android
     BrekekeUtils.setUserAgentConfig(userAgent)
     return userAgent
   }

--- a/src/stores/authStore2.ts
+++ b/src/stores/authStore2.ts
@@ -108,7 +108,7 @@ export class AuthStore {
     ['waiting', 'connecting', 'failure'].some(s => s === this.ucState)
 
   isConnFailure = (): boolean => {
-    if (this.ucLoginFromAnotherPlace) {
+    if (this.pbxLoginFromAnotherPlace || this.ucLoginFromAnotherPlace) {
       return true
     }
     const states = [
@@ -276,7 +276,7 @@ export class AuthStore {
     authSIP.auth()
   }
 
-  @action resetFailureStateIncludePbxOrUc = async () => {
+  @action resetFailureStateIncludePbxOrUc = () => {
     this.resetFailureState()
     if (this.pbxLoginFromAnotherPlace) {
       this.pbxLoginFromAnotherPlace = false

--- a/src/stores/authStore2.ts
+++ b/src/stores/authStore2.ts
@@ -60,6 +60,7 @@ export class AuthStore {
   @observable ucTotalFailure = 0
 
   @observable pbxLoginFromAnotherPlace = false
+  @observable showMsgPbxLoginFromAnotherPlace = false
   @observable ucLoginFromAnotherPlace = false
 
   pbxShouldAuth = () =>
@@ -107,7 +108,7 @@ export class AuthStore {
     ['waiting', 'connecting', 'failure'].some(s => s === this.ucState)
 
   isConnFailure = (): boolean => {
-    if (this.pbxLoginFromAnotherPlace || this.ucLoginFromAnotherPlace) {
+    if (this.ucLoginFromAnotherPlace) {
       return true
     }
     const states = [
@@ -275,10 +276,11 @@ export class AuthStore {
     authSIP.auth()
   }
 
-  @action resetFailureStateIncludePbxOrUc = () => {
+  @action resetFailureStateIncludePbxOrUc = async () => {
     this.resetFailureState()
     if (this.pbxLoginFromAnotherPlace) {
       this.pbxLoginFromAnotherPlace = false
+      this.showMsgPbxLoginFromAnotherPlace = false
       authPBX.auth()
     }
     if (this.ucLoginFromAnotherPlace) {


### PR DESCRIPTION
#990
Call is not connected well if other device reconencts while existing one is receiving incoming call

(1) login Brekeke phone (user A) device1 then device2 (use same phonetype)
=> it show ""Logged in from anothe location as the same phone"" on device1.
(2) Making a call to user A
(3) Call goes to device2
(4) While call is rining on device2, try reconneting to Server on Brekeke phone of Device1.
=> Reconnect successfully on device1.
(5) Answer incoming call on device2.
=> Call is not connected well.
With android, it shows connecting on screen.
With iOS. call is connected without voice

#991
Cannot not disconect call well if other device reconnect while existing one is talking

(1) login Brekeke phone (user A) device1 then device2 (use same phonetype)
=> it show ""Logged in from anothe location as the same phone"" on device1.
(2) Making a call to user A
(3) Call goes to device2, and answer the call.
(4) While talinkg on device2, try reconneting to Sever on Brekeke phone of Device1.
=> Reconnect successfully on device1.
(5) Disconnect call on device 2.
=> Call is not disconected well.
With android, it shows a strange sceen after disconnect.
With iOS. Call screen does not response, and cannot disconnect the call.

#992
PN call arrives to a device that show "Login from another location..." if trying to reconnect from different device for more 3 times

(1) login Brekeke phone (user A, phone type1) on device1.
(2) Login Brekeke phone (user A, phone type1) on device2
=> Login sucessfully on device2, and error ""Login infrom another location as the same phone"" display on device1.
(3) Repeat step1.
=> Reconnect sucessfully on device1, and error ""Login infrom another location as the same phone"" display on device2.
(4) Make a call to the user A.
=> PN call arrives to device2, and sip call show on device1.
Expected: PN call arrive to device 1 only.