### PR TITLE
Fix issue 998: Unable to fetch PhoneAppli Avatar when the PBX disconnects during a request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 2.15.6
+
+- Fix it should getPhoneAppliContact properly when the pbx disconnects during a request (issue 998)
+
 #### 2.15.5
 
 - Fix notify_park

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -64,8 +64,8 @@ android {
     minSdkVersion rootProject.ext.minSdkVersion
     targetSdkVersion rootProject.ext.targetSdkVersion
     multiDexEnabled true
-    versionCode 215005
-    versionName "2.15.5"
+    versionCode 215006
+    versionName "2.15.6"
   }
 
   signingConfigs {

--- a/ios/BrekekePhone.xcodeproj/project.pbxproj
+++ b/ios/BrekekePhone.xcodeproj/project.pbxproj
@@ -816,7 +816,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift$(inherited)";
-				MARKETING_VERSION = 2.15.5;
+				MARKETING_VERSION = 2.15.6;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brekeke.phonedev.BrekekeLPCExtension;
@@ -858,7 +858,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift$(inherited)";
-				MARKETING_VERSION = 2.15.5;
+				MARKETING_VERSION = 2.15.6;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brekeke.phonedev.BrekekeLPCExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/BrekekePhone/Info.plist
+++ b/ios/BrekekePhone/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.15.5</string>
+	<string>2.15.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brekekephone",
-  "version": "2.15.5",
+  "version": "2.15.6",
   "private": true,
   "homepage": "./",
   "scripts": {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -69,6 +69,19 @@ class Api {
       updatePhoneAppli()
     }
 
+    // handle pending request when pbx start
+    pbx.pendingRequests.forEach(({ funcName, params, callback }) => {
+      pbx[funcName](...params)
+        .then(callback)
+        .catch(err => {
+          console.error(
+            `Pbx debug: Try to call ${funcName} more. But still get error:`,
+            err,
+          )
+        })
+    })
+    pbx.pendingRequests = []
+
     contactStore.loadContacts()
     // load list local  when pbx start
     // set default pbxLocalAllUsers = true

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -71,11 +71,16 @@ class Api {
 
     // handle pending request when pbx start
     pbx.pendingRequests.forEach(({ funcName, params, callback }) => {
-      pbx[funcName](...params)
+      const fn = pbx[funcName] as Function
+      if (!fn) {
+        console.error(`PBX debug: can not find method ${funcName}`)
+        return
+      }
+      fn.apply(pbx, params)
         .then(callback)
         .catch(err => {
           console.error(
-            `Pbx debug: Try to call ${funcName} more. But still get error:`,
+            `PBX debug: try to call ${funcName} more but still get error:`,
             err,
           )
         })

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -47,7 +47,7 @@ export class PBX extends EventEmitter {
   isMainInstance = true
 
   pendingRequests: {
-    funcName: string
+    funcName: keyof PBX
     params: string[]
     callback: Function
   }[] = []

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -46,6 +46,12 @@ export class PBX extends EventEmitter {
   // wait auth state to success
   isMainInstance = true
 
+  pendingRequests: {
+    funcName: string
+    params: string[]
+    callback: Function
+  }[] = []
+
   connect = async (
     a: Account,
     palParamUserReconnect?: boolean,
@@ -546,16 +552,12 @@ export class PBX extends EventEmitter {
     if (!this.client) {
       return
     }
-    try {
-      const res = await this.client.call_pal('getPhoneAppliContact', {
-        tenant,
-        user,
-        tel,
-      })
-      return res
-    } catch (err) {
-      return {}
-    }
+    const res = await this.client.call_pal('getPhoneAppliContact', {
+      tenant,
+      user,
+      tel,
+    })
+    return res
   }
   getContact = async (id: string) => {
     if (this.isMainInstance) {

--- a/src/stores/callStore2.ts
+++ b/src/stores/callStore2.ts
@@ -267,10 +267,11 @@ export class CallStore {
     const partyName = res?.display_name || c.partyName
     const partyImageSize = res?.image_url ? 'large' : c.partyImageSize
 
-    const call = this.calls.find(
+    // this method is called after an async operator and the call might be ended
+    const stillExist = this.calls.some(
       _ => _.callkeepUuid === c.callkeepUuid || _.id === c.id,
     )
-    if (!call) {
+    if (!stillExist) {
       return
     }
 
@@ -386,7 +387,7 @@ export class CallStore {
           this.updatePhoneAppliAvatar(c, res)
         })
         .catch(err => {
-          console.error('Pbx debug: getPhoneappliContact error:', err)
+          console.error('PBX debug: getPhoneappliContact error:', err)
           pbx.pendingRequests.push({
             funcName: 'getPhoneappliContact',
             params: [pbxTenant, pbxUsername, c.partyNumber],


### PR DESCRIPTION
Device]
1006: BrekekePhone (Android)
1007: BrekekePhone (iPhone)
[Procedure]

1. Call from 1007 to 1006. Turn off the screen of 1007 by turning on the proximity sensor.

2. 1006 answers and the call begins.

3. After approximately 140 seconds, 1007's proximity sensor is turned off and the screen is turned on.

4. 1006 disconnects the call.

5. 1007 calls 1006 again.

6. The PhoneAppli image is not displayed on 1007.