### PR TITLE
Issue #1005:  where PBX does not reconnect when in background mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### 2.15.6
 
 - Fix it should getPhoneAppliContact properly when the pbx disconnects during a request (issue 998)
+- Fix it should reconnect pbx when in background mode (issue 1005)
 
 #### 2.15.5
 

--- a/src/stores/authStore2.ts
+++ b/src/stores/authStore2.ts
@@ -76,7 +76,11 @@ export class AuthStore {
     (this.pbxState === 'stopped' ||
       (this.pbxState === 'failure' &&
         // !this.pbxTotalFailure &&
-        RnAppState.currentState === 'active'))
+        RnAppState.currentState === 'active') ||
+      (this.pbxState === 'failure' &&
+        this.sipState === 'success' &&
+        RnAppState.currentState === 'background' &&
+        getCallStore().calls.length))
   pbxConnectingOrFailure = () =>
     ['waiting', 'connecting', 'failure'].some(s => s === this.pbxState)
 


### PR DESCRIPTION
**Step:** 
(1) Login brekekephone and run foreground mode 
(2) Press Power button to sleep phone 
(3) Within 10s, Change network (LTE <-> Wifi) while sleeping 
(4) Around 10s after that,  Make call to Brekekephone and answer it 
  | *** Make after longer time (30s, 90s)
(5) Wait 104s then pressing Hold button 
=> It work well 
(6) Repeat step (2), (3), (4) 
(7) Press Hold button (not wait 104s) 
=> Hold button is changed but the call is not put on hold 
After a while, the icon will be released from hold. 
(8) Press Record button 
=> It does not work 
**Issue is not released if not unlock screeen and reopen app 
*** Note: Need to close/reopen Brekeke phone in order to release the problem for next calls 
  
**Rate: 4/8 calls 
**It happens with/without PINGPONG config 
**Device: Samsung Galaxy A14, Android 14 OS 