### PR TITLE
Fix issue #1009: Can not load app when pressing PN message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix it should getPhoneAppliContact properly when the pbx disconnects during a request (issue 998)
 - Fix it should reconnect pbx when in background mode (issue 1005)
+- Fix app should work properly without hanging when pressing a PN item (issue 1009)
 
 #### 2.15.5
 

--- a/src/pages/PageChatRecents.tsx
+++ b/src/pages/PageChatRecents.tsx
@@ -150,12 +150,13 @@ export class PageChatRecents extends Component {
 
     // don't display webchat
     arr = arr.filter(c => !webchatInactive.some(gr => gr.id === c.id))
-    arr = orderBy(arr, ['created', 'name'])
-      // .filter(c => !!c.created && !c.group)
-      .reverse()
 
     // when anyItem changes page will be render again => don't need timeout
     this.saveLastChatItem(arr)
+
+    arr = orderBy(arr, ['created', 'name'])
+      // .filter(c => !!c.created && !c.group)
+      .reverse()
 
     return (
       <Layout


### PR DESCRIPTION
### STEP
(1) A logins to IOS, B logins to Android
(2) Kill app
(3) B and C sent PN message at the same time
=> A received B's and C's message
(4) A tapped on 2nd message which it shows on top
=> App was loaded well
(5) Kill app
(6) A tapped on the remaining message in notification bar
=> App was not loaded properly (NG)
(7) A killed app then reopening
=> App loaded well
(8) A killed app then B sent message to A
(9) A tapped PN message in notification bar
=> App was not loaded properly (NG)
(10) Reopen app then going to some screen and goes to Chat tab
=> Can not access Chat tab and other screen (NG)
(11) Reopen app
=> App can not load (NG)