### PR TITLE
Fix issue #1012: Unable to connect to PBX when the app is in sleep mode using 5G/4G.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Fix it should reconnect pbx when in background mode (issue 1005)
 - Fix it should work properly without hanging when pressing a PN item (issue 1009)
 - Fix it should work proplery in transfer video, affected by the previous issue 934 (issue 1010)
+- Fix it should reconnect pbx after wake up from background mode in GSM internet (issue 1012)
+- Add logic to only get contacts and sync PN token after 10m from the last pbx connect
 
 #### 2.15.5
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -123,10 +123,12 @@ class Api {
   onPBXConnectionStopped = () => {
     getAuthStore().pbxState = 'stopped'
     getAuthStore().pbxTotalFailure += 1
+    getAuthStore().pbxConnectedAt = 0
   }
   onPBXConnectionTimeout = () => {
     getAuthStore().pbxState = 'failure'
     getAuthStore().pbxTotalFailure += 1
+    getAuthStore().pbxConnectedAt = 0
     authPBX.auth()
   }
   onPBXUserCalling = (ev: UserTalkerEvent) => {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -59,24 +59,6 @@ class Api {
     s.pbxState = 'success'
     s.pbxTotalFailure = 0
 
-    // when pbx reconnects due to timeout, we wait for successConnectCheckPeriod before
-    // attempting to syncPnToken, getPbxConfig, and getPbxUsers again
-    const now = Date.now()
-    console.log(
-      `PBX PN debug: onPBXConnectionStarted pbxConnectedAt=${s.pbxConnectedAt} ,
-      now=${now} successConnectCheckPeriod=${successConnectCheckPeriod} ,
-      now - s.pbxConnectedAt=${now - s.pbxConnectedAt} ms`,
-    )
-    if (
-      s.pbxConnectedAt &&
-      now - s.pbxConnectedAt < successConnectCheckPeriod
-    ) {
-      console.log(
-        'PBX PN debug: onPBXConnectionStarted try to skip syncPnToken, getPbxConfig, getPbxUsers',
-      )
-      return
-    }
-
     authSIP.auth()
     await waitSip()
 
@@ -107,6 +89,24 @@ class Api {
         })
     })
     pbx.pendingRequests = []
+
+    // when pbx reconnects due to timeout, we wait for successConnectCheckPeriod before
+    // attempting to syncPnToken, getPbxConfig, and getPbxUsers again
+    const now = Date.now()
+    console.log(
+      `PBX PN debug: onPBXConnectionStarted pbxConnectedAt=${s.pbxConnectedAt} ,
+      now=${now} successConnectCheckPeriod=${successConnectCheckPeriod} ,
+      now - s.pbxConnectedAt=${now - s.pbxConnectedAt} ms`,
+    )
+    if (
+      s.pbxConnectedAt &&
+      now - s.pbxConnectedAt < successConnectCheckPeriod
+    ) {
+      console.log(
+        'PBX PN debug: onPBXConnectionStarted try to skip syncPnToken, getPbxConfig, getPbxUsers',
+      )
+      return
+    }
 
     contactStore.loadContacts()
     // load list local  when pbx start

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import type { WebViewSource } from 'react-native-webview/lib/WebViewTypes'
 
+export const successConnectCheckPeriod = 600000 // 10 minutes
 export const fcmApplicationId = '22177122297'
 export const bundleIdentifier = 'com.brekeke.phonedev'
 

--- a/src/stores/Call.ts
+++ b/src/stores/Call.ts
@@ -12,6 +12,8 @@ import { getPartyName } from '../stores/contactStore'
 import { checkPermForCall } from '../utils/permissions'
 import { BrekekeUtils } from '../utils/RnNativeModules'
 import { waitTimeout } from '../utils/waitTimeout'
+import { authPBX } from './AuthPBX'
+import { getAuthStore } from './authStore'
 import type { CallStore } from './callStore2'
 import { contactStore } from './contactStore'
 import { intlDebug } from './intl'
@@ -195,6 +197,8 @@ export class Call {
         : intlDebug`Failed to start recording the call`
       RnAlert.error({ message, err })
     }
+    // try to re-auth if error is timeout
+    this.checkTimeoutToReconnectPbx(err)
   }
 
   toggleHoldWithCheck = () => {
@@ -213,14 +217,34 @@ export class Call {
     if (!this.isAboutToHangup && fn === 'unhold') {
       this.store.setCurrentCallId(this.id)
     }
+
     return pbx[`${fn}Talker`](this.pbxTenant, this.pbxTalkerId)
       .then(this.onToggleHoldFailure)
       .catch(this.onToggleHoldFailure)
+  }
+
+  private checkTimeoutToReconnectPbx = (err: Error | boolean) => {
+    if (err === true) {
+      return
+    }
+    if (
+      err &&
+      typeof err === 'object' &&
+      (('code' in err && (err as any).code === -1) ||
+        ('message' in err && /timeout/i.test(err.message)))
+    ) {
+      getAuthStore().pbxState = 'stopped'
+      authPBX.dispose()
+      authPBX.auth()
+    }
   }
   @action private onToggleHoldFailure = (err: Error | boolean) => {
     if (err === true) {
       return true
     }
+    // try to re-auth if error is timeout
+    this.checkTimeoutToReconnectPbx(err)
+
     const prevFn = this.holding ? 'hold' : 'unhold'
     this.setHolding(prevFn === 'unhold')
     if (typeof err !== 'boolean') {
@@ -269,6 +293,8 @@ export class Call {
       message: intlDebug`Failed to transfer the call`,
       err,
     })
+    // try to re-auth if error is timeout
+    this.checkTimeoutToReconnectPbx(err)
   }
 
   @action stopTransferring = () => {
@@ -287,6 +313,8 @@ export class Call {
       message: intlDebug`Failed to stop the transfer`,
       err,
     })
+    // try to re-auth if error is timeout
+    this.checkTimeoutToReconnectPbx(err)
   }
 
   @action conferenceTransferring = () => {
@@ -305,6 +333,8 @@ export class Call {
       message: intlDebug`Failed to make conference for the transfer`,
       err,
     })
+    // try to re-auth if error is timeout
+    this.checkTimeoutToReconnectPbx(err)
   }
 
   @action park = (number: string) =>
@@ -316,6 +346,8 @@ export class Call {
       message: intlDebug`Failed to park the call`,
       err,
     })
+    // try to re-auth if error is timeout
+    this.checkTimeoutToReconnectPbx(err)
   }
 
   private _autorunEmitEmbed = false // check if autorun is already started

--- a/src/stores/authStore2.ts
+++ b/src/stores/authStore2.ts
@@ -200,6 +200,7 @@ export class AuthStore {
     }
 
     this.signedInId = a.id
+    this.pbxConnectedAt = 0
     BrekekeUtils.setPhoneappliEnabled(!!this.phoneappliEnabled())
     if (!autoSignIn) {
       await saveLastSignedInId(getAccountUniqueId(a))

--- a/src/stores/authStore2.ts
+++ b/src/stores/authStore2.ts
@@ -64,6 +64,8 @@ export class AuthStore {
   @observable showMsgPbxLoginFromAnotherPlace = false
   @observable ucLoginFromAnotherPlace = false
 
+  @observable pbxConnectedAt = 0
+
   pbxShouldAuth = () =>
     this.getCurrentAccount() &&
     !this.pbxLoginFromAnotherPlace &&
@@ -268,6 +270,7 @@ export class AuthStore {
     this.userExtensionProperties = null
     this.cRecentCalls = []
     this.rcPage = 0
+    this.pbxConnectedAt = 0
   }
 
   @action resetFailureState = () => {
@@ -300,6 +303,7 @@ export class AuthStore {
       this.pbxLoginFromAnotherPlace = false
       this.showMsgPbxLoginFromAnotherPlace = false
       authPBX.auth()
+      getAuthStore().pbxConnectedAt = 0
     }
     if (this.ucLoginFromAnotherPlace) {
       this.ucLoginFromAnotherPlace = false


### PR DESCRIPTION
Akira:
1. While BrekekePhone is in the foreground, press the power button to put it to sleep.
2. BrekekePhone receives a call and answers it.
3. Turn off the screen by turning on the neighborhood sensor.
4. After about 4 minutes, turn the screen on by turning off the neighborhood sensor.
5. Press the Hold button.
⇒ The icon is put on hold, but it is not put on hold.
After a short period of time, the icon will be released from hold
