### PR TITLE
Fix issue #1010: Video is not loaded and crash app when canceling transfer video call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 - Fix it should getPhoneAppliContact properly when the pbx disconnects during a request (issue 998)
 - Fix it should reconnect pbx when in background mode (issue 1005)
-- Fix app should work properly without hanging when pressing a PN item (issue 1009)
+- Fix it should work properly without hanging when pressing a PN item (issue 1009)
+- Fix it should work proplery in transfer video, affected by the previous issue 934 (issue 1010)
 
 #### 2.15.5
 

--- a/src/api/sip.ts
+++ b/src/api/sip.ts
@@ -1,6 +1,5 @@
 import EventEmitter from 'eventemitter3'
 import jsonStableStringify from 'json-stable-stringify'
-import { isEmpty } from 'lodash'
 import { Platform } from 'react-native'
 
 import type { CallOptions, Session, Sip } from '../brekekejs'
@@ -259,22 +258,31 @@ export class SIP extends EventEmitter {
       if (!ev) {
         return
       }
-      // videoClientSessionCreated not fired if local caller has phone_id < remote callee phone_id
+      // Issue #934: videoClientSessionCreated not fired if local caller has phone_id < remote callee phone_id
       //    reproduce:
       //      - caller make video call to callee
       //      - callee answer with video
       //      - callee disable video, then enable again
       //      - issue: -> caller show loading, callee black remote video
       // the issue is because of webrtclient.js but we can not modify it
-      if (
-        ev.remoteWithVideo &&
-        isEmpty(ev.videoClientSessionTable) &&
-        ev.withVideo &&
-        ev.rtcSession.direction !== 'incoming'
-      ) {
-        this.disableVideo(ev.sessionId)
-        this.enableVideo(ev.sessionId)
-      }
+
+      // if (
+      //   ev.remoteWithVideo &&
+      //   isEmpty(ev.videoClientSessionTable) &&
+      //   ev.withVideo &&
+      //   ev.rtcSession.direction !== 'incoming' &&
+      //   !getCallStore().getOngoingCall()?.transferring
+      // ) {
+      //   this.disableVideo(ev.sessionId)
+      //   this.enableVideo(ev.sessionId)
+      // }
+      // The above logic seems unnecessary. The bug (#934) has been fixed somewhere else.
+
+      // for Duy fixed issue video call
+      // this.emit('session-updated', {
+      //   id: ev.sessionId,
+      //   remoteUserOptionsTable: ev.remoteUserOptionsTable,
+      // })
     })
 
     phone.addEventListener('rtcErrorOccurred', ev => {

--- a/src/api/sip.ts
+++ b/src/api/sip.ts
@@ -258,7 +258,11 @@ export class SIP extends EventEmitter {
       if (!ev) {
         return
       }
-      // Issue #934: videoClientSessionCreated not fired if local caller has phone_id < remote callee phone_id
+
+      // TODO #934 this issue has been fixed somewhere else, can not reproduce
+      // however this caused #1010, we remove it here for now
+
+      // videoClientSessionCreated not fired if local caller has phone_id < remote callee phone_id
       //    reproduce:
       //      - caller make video call to callee
       //      - callee answer with video
@@ -276,9 +280,8 @@ export class SIP extends EventEmitter {
       //   this.disableVideo(ev.sessionId)
       //   this.enableVideo(ev.sessionId)
       // }
-      // The above logic seems unnecessary. The bug (#934) has been fixed somewhere else.
 
-      // for Duy fixed issue video call
+      // TODO DuyP to fix issues related to video call
       // this.emit('session-updated', {
       //   id: ev.sessionId,
       //   remoteUserOptionsTable: ev.remoteUserOptionsTable,


### PR DESCRIPTION
[Reproduce Android]
(1) A logined Android, B logined IOS
(2) A made video call to B > B answer
=> The video call was connected well
(3) B made attendant transfer to C > C picks up video call
(4) B canceled transfer
=> A's and B's were not loaded video (NG)
(5) A tapped some buttons on Call screen
=> The buttons were not changed, after a while A's call screen was disappeared and the call was dropped (NG)
(10) Reopen app then going to some screen and goes to Chat tab (same #1009)
=> Can not access Chat tab and other screen (NG)
(11) Reopen app
=> App can not load (NG)

**It happens with both Android and IOS:
- Android: same step above
- IOS: Call screen was kept but the buttons not work and the call was dropped


[IOS]:
(1) A logined Android, B logined IOS
(2) B made video call to A > A answered
=> The video call was connected well
(3) A made attendant transfer to C > C picked up video call
(4) A canceled transfer
=> A's and B's were not loaded video (NG)
(5) Tap Speaker button on A's and B's screen then tapping Hold button on A's
(6) Tap some buttons on B's
=> The buttons not work (NG)

**In step 6, if the buttons of B still work, so reopen app then going to some screen and goes to Chat tab (same #1009) => Can not access Chat tab and other screen (NG)
