### PR TITLE
Fix issue #1016: [Android] One way voice when switching app from foreground mode to background or lock screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 2.15.7
+
+- Fix android 14 sdk 34 it should have microphone work with new permission policy (issue 1016)
+
 #### 2.15.6
 
 - Fix it should getPhoneAppliContact properly when the pbx disconnects during a request (issue 998)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -64,8 +64,8 @@ android {
     minSdkVersion rootProject.ext.minSdkVersion
     targetSdkVersion rootProject.ext.targetSdkVersion
     multiDexEnabled true
-    versionCode 215006
-    versionName "2.15.6"
+    versionCode 215007
+    versionName "2.15.7"
   }
 
   signingConfigs {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -48,6 +48,15 @@
   <uses-permission
     android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"
   />
+  <!--   Use this to target android >= 14-->
+  <uses-permission
+    android:minSdkVersion="34"
+    android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"
+  />
+  <uses-permission
+    android:minSdkVersion="34"
+    android:name="android.permission.FOREGROUND_SERVICE_CAMERA"
+  />
 
   <!-- call history -->
   <!-- temporary disabled

--- a/ios/BrekekePhone.xcodeproj/project.pbxproj
+++ b/ios/BrekekePhone.xcodeproj/project.pbxproj
@@ -816,7 +816,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift$(inherited)";
-				MARKETING_VERSION = 2.15.6;
+				MARKETING_VERSION = 2.15.7;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brekeke.phonedev.BrekekeLPCExtension;
@@ -858,7 +858,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift$(inherited)";
-				MARKETING_VERSION = 2.15.6;
+				MARKETING_VERSION = 2.15.7;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brekeke.phonedev.BrekekeLPCExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/BrekekePhone/Info.plist
+++ b/ios/BrekekePhone/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.15.6</string>
+	<string>2.15.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brekekephone",
-  "version": "2.15.6",
+  "version": "2.15.7",
   "private": true,
   "homepage": "./",
   "scripts": {


### PR DESCRIPTION
### Reproduced
(1) User A logins to Brekeke phone then running foreground
(2) Make call to A > A answers
=> The call is connected well
(3) A switches Brekeke phone app to background
=> Caller side can not hear any thing when A talks (NG)
(4) A switches Brekeke phone foreground
=> The call is connected well in both side

**It also happens with cases lock screen by pressing Power button when talking or receiving call/message (open message) from other app
**It only happens with some device
Test device: Samsung galaxy A14 - Android 14