### PR TITLE
Fix issue 1017: Call one way voice after the second call arrives while talking and switching to background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 #### 2.15.8
 
-- Fix android 14 sdk 34 it should have microphone work with new permission policy (issue 1017)
+- Fix android 14 sdk 34 it should have microphone work in background with multiple calls, by patching callkeep library (issue 1017)
 
 #### 2.15.7
 
-- Fix android 14 sdk 34 it should have microphone work with new permission policy (issue 1016)
+- Fix android 14 sdk 34 it should have microphone work in background, by adding new permissions (issue 1016)
 
 #### 2.15.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 2.15.8
+
+- Fix android 14 sdk 34 it should have microphone work with new permission policy (issue 1017)
+
 #### 2.15.7
 
 - Fix android 14 sdk 34 it should have microphone work with new permission policy (issue 1016)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -64,8 +64,8 @@ android {
     minSdkVersion rootProject.ext.minSdkVersion
     targetSdkVersion rootProject.ext.targetSdkVersion
     multiDexEnabled true
-    versionCode 215007
-    versionName "2.15.7"
+    versionCode 215008
+    versionName "2.15.8"
   }
 
   signingConfigs {

--- a/ios/BrekekePhone.xcodeproj/project.pbxproj
+++ b/ios/BrekekePhone.xcodeproj/project.pbxproj
@@ -816,7 +816,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift$(inherited)";
-				MARKETING_VERSION = 2.15.7;
+				MARKETING_VERSION = 2.15.8;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brekeke.phonedev.BrekekeLPCExtension;
@@ -858,7 +858,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift$(inherited)";
-				MARKETING_VERSION = 2.15.7;
+				MARKETING_VERSION = 2.15.8;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brekeke.phonedev.BrekekeLPCExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/BrekekePhone/Info.plist
+++ b/ios/BrekekePhone/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.15.7</string>
+	<string>2.15.8</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brekekephone",
-  "version": "2.15.7",
+  "version": "2.15.8",
   "private": true,
   "homepage": "./",
   "scripts": {

--- a/patches/react-native-callkeep+4.3.9.patch
+++ b/patches/react-native-callkeep+4.3.9.patch
@@ -395,7 +395,7 @@ index 1ea76fb..675b7ae 100644
          sendCallRequestToActivity(ACTION_SHOW_INCOMING_CALL_UI, handle);
      }
 diff --git a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
-index f53c052..b8a0e24 100644
+index f53c052..68631a1 100644
 --- a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
 +++ b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
 @@ -51,6 +51,8 @@ import android.util.Log;
@@ -457,6 +457,20 @@ index f53c052..b8a0e24 100644
  
          if (foregroundSettings.hasKey("notificationIcon")) {
              Context context = this.getApplicationContext();
+@@ -352,6 +368,13 @@ public class VoiceConnectionService extends ConnectionService {
+             return;
+         }
+ 
++        // Fix multiple voice connection service, when more than 1 connection service is running
++        // don't stop foreground service to avoid issue no-voice (permission for microphone ) on Android 14 and above
++        if (currentConnections.size() > 1 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
++            Log.d(TAG, "[VoiceConnectionService] Skip stop foreground service due to multiple active connections on Android 14+");
++            return;
++        }
++        
+         try {
+             stopForeground(FOREGROUND_SERVICE_TYPE_MICROPHONE);
+         } catch (Exception e) {
 diff --git a/node_modules/react-native-callkeep/index.d.ts b/node_modules/react-native-callkeep/index.d.ts
 index ee1a7fb..a6230f9 100644
 --- a/node_modules/react-native-callkeep/index.d.ts
@@ -536,7 +550,7 @@ index c8e7bbd..052f0ac 100644
  + (void)reportNewIncomingCall:(NSString *)uuidString
                         handle:(NSString *)handle
 diff --git a/node_modules/react-native-callkeep/ios/RNCallKeep/RNCallKeep.m b/node_modules/react-native-callkeep/ios/RNCallKeep/RNCallKeep.m
-index e67c3cd..52fcfc6 100644
+index e67c3cd..6780f95 100644
 --- a/node_modules/react-native-callkeep/ios/RNCallKeep/RNCallKeep.m
 +++ b/node_modules/react-native-callkeep/ios/RNCallKeep/RNCallKeep.m
 @@ -47,7 +47,6 @@ @implementation RNCallKeep


### PR DESCRIPTION
Steps:
(1) Login Brekeke phone (Android)
(2) Make 2 calls to the Brekeke phone.
(3) After that disconnect one of the call, and keep one call and talking.
(4) Switch Brekeke phone to background while talking.
=> the other side cannot hear voice from Brekeke phone.
Brekeke phone still hear voice of other side.
*** The issue also happen at step2 make the first call and talking, then make a miscall to the Brekeke phone, then continue step4.