### PR TITLE
Fix issue 982: It should show notification when incoming message even while Chat list/Chat private is opening

### DIFF
--- a/src/components/ChatGroupInvite.tsx
+++ b/src/components/ChatGroupInvite.tsx
@@ -7,6 +7,7 @@ import { StyleSheet, View } from 'react-native'
 
 import { uc } from '../api/uc'
 import { mdiCheck, mdiClose } from '../assets/icons'
+import { getCallStore } from '../stores/callStore'
 import { chatStore } from '../stores/chatStore'
 import { contactStore } from '../stores/contactStore'
 import { intl, intlDebug } from '../stores/intl'
@@ -212,6 +213,13 @@ export class UnreadChatNoti extends Component {
       if (isWebchat && !isWebchatJoined) {
         return false
       }
+
+      // Always show chat message notifications when in Call manage screen
+      const inPageCallManage = getCallStore().inPageCallManage
+      if (!!inPageCallManage) {
+        return true
+      }
+
       const { name, buddy, groupId } = s
 
       if (name === 'PageChatRecents') {


### PR DESCRIPTION
### Step:
(1) User A logins brekeke phone on IOS and talking
(2) Go to Chat list or Chat private then back call screen
(3) Send new message to A
=> A does not receive any notification when new incoming message (NG)
Expect: It should show notification when incoming message even while Chat list/Chat private is opening

** Android does not receive notification when chat private is opening