### PR TITLE
Fix issue PAL connection

### DIFF
--- a/src/brekekejs/index.d.ts
+++ b/src/brekekejs/index.d.ts
@@ -202,6 +202,7 @@ export type PbxPal = {
   cancelTransfer: PbxPal['hold']
   park(p: PbxParkParam, resolve: () => void, reject: ErrorHandler): void
   sendDTMF(p: PbxSendDtmfParam, resolve: () => void, reject: ErrorHandler): void
+  ping(p: undefined, resolve: () => void, reject: ErrorHandler): void
 }
 
 export type PbxResourceLine = {

--- a/src/brekekejs/pal.js
+++ b/src/brekekejs/pal.js
@@ -112,6 +112,7 @@ Brekeke.pbx.getPalPrototype = function () {
     'getToken',
     'getVoicemails',
     'getTalkerInfo',
+    'ping',
   ]
   for (var i = 0; i < pal.methods.length; i++) {
     pal.regMethod(pal.methods[i])

--- a/src/stores/Call.ts
+++ b/src/stores/Call.ts
@@ -197,8 +197,6 @@ export class Call {
         : intlDebug`Failed to start recording the call`
       RnAlert.error({ message, err })
     }
-    // try to re-auth if error is timeout
-    this.checkTimeoutToReconnectPbx(err)
   }
 
   toggleHoldWithCheck = () => {
@@ -223,27 +221,10 @@ export class Call {
       .catch(this.onToggleHoldFailure)
   }
 
-  private checkTimeoutToReconnectPbx = (err: Error | boolean) => {
-    if (err === true) {
-      return
-    }
-    if (
-      err &&
-      typeof err === 'object' &&
-      (('code' in err && (err as any).code === -1) ||
-        ('message' in err && /timeout/i.test(err.message)))
-    ) {
-      getAuthStore().pbxState = 'stopped'
-      authPBX.dispose()
-      authPBX.auth()
-    }
-  }
   @action private onToggleHoldFailure = (err: Error | boolean) => {
     if (err === true) {
       return true
     }
-    // try to re-auth if error is timeout
-    this.checkTimeoutToReconnectPbx(err)
 
     const prevFn = this.holding ? 'hold' : 'unhold'
     this.setHolding(prevFn === 'unhold')
@@ -293,8 +274,6 @@ export class Call {
       message: intlDebug`Failed to transfer the call`,
       err,
     })
-    // try to re-auth if error is timeout
-    this.checkTimeoutToReconnectPbx(err)
   }
 
   @action stopTransferring = () => {
@@ -313,8 +292,6 @@ export class Call {
       message: intlDebug`Failed to stop the transfer`,
       err,
     })
-    // try to re-auth if error is timeout
-    this.checkTimeoutToReconnectPbx(err)
   }
 
   @action conferenceTransferring = () => {
@@ -333,8 +310,6 @@ export class Call {
       message: intlDebug`Failed to make conference for the transfer`,
       err,
     })
-    // try to re-auth if error is timeout
-    this.checkTimeoutToReconnectPbx(err)
   }
 
   @action park = (number: string) =>
@@ -346,8 +321,6 @@ export class Call {
       message: intlDebug`Failed to park the call`,
       err,
     })
-    // try to re-auth if error is timeout
-    this.checkTimeoutToReconnectPbx(err)
   }
 
   private _autorunEmitEmbed = false // check if autorun is already started


### PR DESCRIPTION
Sometimes, when the app goes into sleep mode, PAL gets disconnected without updating its status.

### Step1:
- Connect to a weak Wi-Fi signal
- Enable battery-saving mode
- Press the power button to lock the screen
- Leave the device like that for more than 30 minutes
- Unlock the device and perform a PAL request. At this point, a timeout error will occur.

### step2:
- While BrekekePhone is in the foreground, press the power button to put it into sleep mode.
- Receive an incoming call on BrekekePhone and answer it.
- Turn off the screen by activating the proximity sensor (ON).
- After about 4 minutes, turn the screen back on by deactivating the proximity sensor (OFF).
- Press the hold button.
⇒ The icon changes to the hold state, but the call is not actually put on hold.