### PR TITLE
Fix issue 1006: It show Connecting and keep 00:00 while app is loading

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/BrekekeMessagingService.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/BrekekeMessagingService.java
@@ -38,6 +38,9 @@ public class BrekekeMessagingService extends FcmInstanceIdListenerService {
       BrekekeUtils.emit("phonePermission", "");
       return;
     }
+    // Fix issue #1006: it should close the default dialer permission popup when there is an
+    // incoming call
+    BrekekeUtils.resolveDefaultDialer("The call is incoming");
     BrekekeUtils.onFcmMessageReceived(this, remoteMessage.getData());
 
     if (initialNotifications == null) {


### PR DESCRIPTION
(1) A logins brekeke phone (Android) then killing app, B logins anywhere
(2) A opens app
(3) While app is loading, send request:
https://<domain:port>/pbx/3pcc?tenant=nen002&to=307&from=308&type=2&page=true&phone=4

=> The call is forwarded to A and it always keeps at Connecting and keep 00:00.
**It also happens when A is callee
