### PR TITLE
Fix issue 1031: All buttons are flashed continuously on status bar and call screen when Hold button is double click in status bar

### DIFF
--- a/src/components/CallBar.tsx
+++ b/src/components/CallBar.tsx
@@ -122,6 +122,7 @@ export const CallBar = observer(() => {
             color={oc.holding ? v.colors.primary : v.color}
             onPress={oc.toggleHoldWithCheck}
             path={oc.holding ? mdiPlay : mdiPause}
+            msLoading={1000}
           />
         </View>
       </RnTouchableOpacity>


### PR DESCRIPTION
### Step:
(1) A logins to brekeke phone and makes call to other user
(2) A presses Hold button then pressing Back button
(3) On status bar, press unhold/hold quickly
=> All buttons are flashed and not talking (NG)