### PR TITLE
Fix issue 1044: Service always shows on notification bar and badge

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/lpc/BrekekeLpcService.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/lpc/BrekekeLpcService.java
@@ -59,6 +59,7 @@ public class BrekekeLpcService extends Service {
       NotificationChannel serviceChannel =
           new NotificationChannel(
               LpcUtils.NOTI_CHANNEL_ID, appName, NotificationManager.IMPORTANCE_DEFAULT);
+      serviceChannel.setShowBadge(false);
       NotificationManager manager = getSystemService(NotificationManager.class);
       manager.createNotificationChannel(serviceChannel);
     }


### PR DESCRIPTION
### Step
(1) Install brekeke phone app then killing app 
=> It always shows "Service is running in background" and badge is also counted (+1) even though app is killed without running background (NG)