### PR TITLE
Fix issue 1014, 1050: The call is not established when making call from PhoneAppli while Brekeke phone app is killed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,21 @@
+#### 2.16.4
+
+- Initial implementation of [custom ringtone](./.doc/custom-ringtone.md)
+- Add ctype=2 to pal url params, it should overwrite webphone.pal.param.ctype
+- Fix it should handle deeplink while making call from PhoneAppli (issue 1014)
+- Fix it should save logs when the device is locked (issue 1040)
+- Fix it should not display error message UC connection failure in incoming call (issue 1042)
+- Fix it should not show notification with LPC service (issue 1044)
+- Fix it should logout when app is closed from task manager (issue 1050)
+
 #### 2.16.3
 
 - Upgrade react-native to 0.80 and other available dependencies
 - Upgrade android sdk 35 and ios sdk 18
-- Initial implementation of [custom ringtone](./.doc/custom-ringtone.md)
 - Initial implementation of android lpc
 - Improve video conference according to feedbacks
 - Improve debug log with multiples files, and mark for login logout
-- Add ctype=2 to pal url params, it should overwrite webphone.pal.param.ctype
+- Improve hold pal with pending cache and retry, add toast to show message on android incoming call
 - Fix it should login into the correct account when press on the missed call notification (issue 955)
 - Fix it should update avatar without cache in the next call (issue 958)
 - Fix it should display name from phone book in calls (issue 960)
@@ -16,11 +25,7 @@
 - Fix it should remove PN token if login from another device even if there is an ongoing call (issue 1003)
 - Fix android it should resolve dialer permission automatically when there is an incoming call (issue 1006)
 - Fix android it should open app when press on the running in background notification (issue 1022, 1034)
-- Improve hold pal with pending cache and retry, add toast to show message on android incoming call
 - Fix it should prevent double quickly click hold button (issue 1031)
-- Fix it should save logs when the device is locked (issue 1040)
-- Fix it should not display error message UC connection failure in incoming call (issue 1042)
-- Fix it should not show notification with LPC service (issue 1044)
 - Embed:
   - Disable webphone.resource-line from getProductInfo, allow to set it from embed login instead
   - Add support for setProductName in embed api

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -88,8 +88,8 @@ android {
     minSdkVersion rootProject.ext.minSdkVersion
     targetSdkVersion rootProject.ext.targetSdkVersion
     multiDexEnabled true
-    versionCode 216003
-    versionName "2.16.3"
+    versionCode 216004
+    versionName "2.16.4"
   }
 
   signingConfigs {

--- a/android/app/src/main/java/com/brekeke/phonedev/MainActivity.kt
+++ b/android/app/src/main/java/com/brekeke/phonedev/MainActivity.kt
@@ -39,6 +39,8 @@ class MainActivity : ReactActivity() {
   override fun onDestroy() {
     BrekekeUtils.main = null
     Ringtone.stop()
+    BrekekeUtils.staticStopRingtone()
+    Emitter.emit("onDestroyMainActivity", "")
     super.onDestroy()
   }
 

--- a/android/app/src/main/java/com/brekeke/phonedev/MainActivity.kt
+++ b/android/app/src/main/java/com/brekeke/phonedev/MainActivity.kt
@@ -39,7 +39,6 @@ class MainActivity : ReactActivity() {
   override fun onDestroy() {
     BrekekeUtils.main = null
     Ringtone.stop()
-    BrekekeUtils.staticStopRingtone()
     Emitter.emit("onDestroyMainActivity", "")
     super.onDestroy()
   }

--- a/ios/BrekekePhone.xcodeproj/project.pbxproj
+++ b/ios/BrekekePhone.xcodeproj/project.pbxproj
@@ -847,7 +847,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift$(inherited)";
-				MARKETING_VERSION = 2.16.3;
+				MARKETING_VERSION = 2.16.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brekeke.phonedev.BrekekeLPCExtension;
@@ -889,7 +889,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift$(inherited)";
-				MARKETING_VERSION = 2.16.3;
+				MARKETING_VERSION = 2.16.4;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brekeke.phonedev.BrekekeLPCExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/BrekekePhone/Info.plist
+++ b/ios/BrekekePhone/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.16.3</string>
+	<string>2.16.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brekekephone",
-  "version": "2.16.3",
+  "version": "2.16.4",
   "private": true,
   "homepage": "./",
   "scripts": {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -58,9 +58,7 @@ const initApp = async () => {
     Object.keys(ctx.call.callkeepMap).length ||
     ctx.sip.phone?.getSessionCount() ||
     ctx.call.calls.length
-
   const checkWakeFromPN = () => ctx.auth.sipPn.sipAuth
-
   const hasCallOrWakeFromPN = checkHasCall() || checkWakeFromPN()
 
   const autoLogin = async () => {
@@ -122,8 +120,8 @@ const initApp = async () => {
       return
     }
     if (checkWakeFromPN()) {
-      // For Android, to ensure the Linking listener is re-registered and handle deeplink
-      // after MainActivity is destroyed and the app is reopened.
+      // ensure Linking listener is re-registered and handle deeplink
+      // after MainActivity is destroyed and the app is reopened
       if (Platform.OS === 'android' && !isAlreadyHandleFirstOpen()) {
         await ctx.auth.handleUrlParams()
       }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7,6 +7,7 @@ import {
   ActivityIndicator,
   AppState,
   DeviceEventEmitter,
+  Platform,
   StyleSheet,
   View,
 } from 'react-native'
@@ -42,6 +43,7 @@ import { RnStackerRoot } from '#/stores/RnStackerRoot'
 import { BackgroundTimer } from '#/utils/BackgroundTimer'
 import { BrekekeUtils } from '#/utils/BrekekeUtils'
 import { setupCallKeepEvents } from '#/utils/callkeep'
+import { isAlreadyHandleFirstOpen } from '#/utils/deeplink'
 import { getConnectionStatus } from '#/utils/getConnectionStatus'
 import { checkPermForCall, permForCall } from '#/utils/permissions'
 import { PushNotification } from '#/utils/PushNotification'
@@ -52,12 +54,14 @@ import { webPromptPermission } from '#/utils/webPromptPermission'
 const initApp = async () => {
   await ctx.intl.wait()
 
-  const checkHasCallOrWakeFromPN = () =>
+  const checkHasCall = () =>
     Object.keys(ctx.call.callkeepMap).length ||
     ctx.sip.phone?.getSessionCount() ||
-    ctx.call.calls.length ||
-    ctx.auth.sipPn.sipAuth
-  const hasCallOrWakeFromPN = checkHasCallOrWakeFromPN()
+    ctx.call.calls.length
+
+  const checkWakeFromPN = () => ctx.auth.sipPn.sipAuth
+
+  const hasCallOrWakeFromPN = checkHasCall() || checkWakeFromPN()
 
   const autoLogin = async () => {
     if (!(await checkPermForCall())) {
@@ -109,9 +113,22 @@ const initApp = async () => {
     ctx.call.onCallKeepAction()
     ctx.pbx.ping()
     ctx.pnToken.syncForAllAccounts()
-    if (checkHasCallOrWakeFromPN() || (await ctx.auth.handleUrlParams())) {
+
+    if (checkHasCall()) {
       return
     }
+    if (checkWakeFromPN()) {
+      // For Android, to ensure the Linking listener is re-registered and handle deeplink
+      // after MainActivity is destroyed and the app is reopened.
+      if (Platform.OS === 'android' && !isAlreadyHandleFirstOpen()) {
+        await ctx.auth.handleUrlParams()
+      }
+      return
+    }
+    if (await ctx.auth.handleUrlParams()) {
+      return
+    }
+
     if (
       !hasCallOrWakeFromPN &&
       ctx.auth.signedInId &&

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -114,6 +114,10 @@ const initApp = async () => {
     ctx.pbx.ping()
     ctx.pnToken.syncForAllAccounts()
 
+    if (Platform.OS === 'android' && !isAlreadyHandleFirstOpen()) {
+      ctx.authUC.auth()
+    }
+
     if (checkHasCall()) {
       return
     }

--- a/src/stores/AuthUC.ts
+++ b/src/stores/AuthUC.ts
@@ -30,6 +30,12 @@ export class AuthUC {
     ctx.auth.ucState = 'stopped'
   }
 
+  @action logoutUC = () => {
+    this.dispose()
+    ctx.auth.ucLoginFromAnotherPlace = false
+    ctx.auth.ucTotalFailure = 0
+  }
+
   @action private authWithoutCatch = async () => {
     ctx.uc.disconnect()
 

--- a/src/stores/AuthUC.ts
+++ b/src/stores/AuthUC.ts
@@ -30,12 +30,6 @@ export class AuthUC {
     ctx.auth.ucState = 'stopped'
   }
 
-  @action logoutUC = () => {
-    this.dispose()
-    ctx.auth.ucLoginFromAnotherPlace = false
-    ctx.auth.ucTotalFailure = 0
-  }
-
   @action private authWithoutCatch = async () => {
     ctx.uc.disconnect()
 
@@ -93,7 +87,6 @@ export class AuthUC {
   }
   @action private loadUsers = () => {
     // update logic loadUcBuddyList when UC connect finish
-
     const ca = ctx.auth.getCurrentAccount()
     if (!ca) {
       return

--- a/src/utils/callkeep.ts
+++ b/src/utils/callkeep.ts
@@ -383,6 +383,7 @@ export const setupCallKeepEvents = async () => {
 
   eventEmitter.addListener('onDestroyMainActivity', () => {
     cleanUpDeepLink()
+    ctx.authUC.logoutUC()
   })
 }
 

--- a/src/utils/callkeep.ts
+++ b/src/utils/callkeep.ts
@@ -15,6 +15,7 @@ import { RnKeyboard } from '#/stores/RnKeyboard'
 import { RnPicker } from '#/stores/RnPicker'
 import { RnStacker } from '#/stores/RnStacker'
 import { BrekekeUtils } from '#/utils/BrekekeUtils'
+import { cleanUpDeepLink } from '#/utils/deeplink'
 import { parse, parseNotificationData } from '#/utils/PushNotification-parse'
 import { waitTimeout } from '#/utils/waitTimeout'
 
@@ -379,6 +380,10 @@ export const setupCallKeepEvents = async () => {
   })
   // TODO: should check additional conditions when user switches between activities
   eventEmitter.addListener('onResume', () => ctx.pbx.ping())
+
+  eventEmitter.addListener('onDestroyMainActivity', () => {
+    cleanUpDeepLink()
+  })
 }
 
 export const onBackPressed = () => {

--- a/src/utils/callkeep.ts
+++ b/src/utils/callkeep.ts
@@ -382,8 +382,9 @@ export const setupCallKeepEvents = async () => {
   eventEmitter.addListener('onResume', () => ctx.pbx.ping())
 
   eventEmitter.addListener('onDestroyMainActivity', () => {
+    console.log('clean up because of onDestroyMainActivity')
     cleanUpDeepLink()
-    ctx.authUC.logoutUC()
+    ctx.auth.signOut()
   })
 }
 

--- a/src/utils/deeplink.ts
+++ b/src/utils/deeplink.ts
@@ -24,13 +24,9 @@ export const openLinkSafely = async (url: string) => {
 }
 
 let alreadyHandleFirstOpen = false
-let urlParams: Promise<UrlParams | null> | UrlParams | null = null
 export const isAlreadyHandleFirstOpen = () => alreadyHandleFirstOpen
-export const cleanUpDeepLink = () => {
-  alreadyHandleFirstOpen = false
-  urlParams = null
-  Linking.removeAllListeners('url')
-}
+
+let urlParams: Promise<UrlParams | null> | UrlParams | null = null
 export const getUrlParams = async () => {
   if (alreadyHandleFirstOpen) {
     return urlParams
@@ -57,6 +53,12 @@ export const getUrlParams = async () => {
   urlParams = Linking.getInitialURL().then(parse)
   return urlParams
 }
+
 export const clearUrlParams = () => {
   urlParams = null
+}
+export const cleanUpDeepLink = () => {
+  alreadyHandleFirstOpen = false
+  urlParams = null
+  Linking.removeAllListeners('url')
 }

--- a/src/utils/deeplink.ts
+++ b/src/utils/deeplink.ts
@@ -25,6 +25,12 @@ export const openLinkSafely = async (url: string) => {
 
 let alreadyHandleFirstOpen = false
 let urlParams: Promise<UrlParams | null> | UrlParams | null = null
+export const isAlreadyHandleFirstOpen = () => alreadyHandleFirstOpen
+export const cleanUpDeepLink = () => {
+  alreadyHandleFirstOpen = false
+  urlParams = null
+  Linking.removeAllListeners('url')
+}
 export const getUrlParams = async () => {
   if (alreadyHandleFirstOpen) {
     return urlParams


### PR DESCRIPTION
### Step
### 1014
The call is not established when making call from PhoneAppli while Brekeke phone app is killed
501: brekeke phone (Android)
502: brekeke phone (IOS)
(1) 501 login brekeke then killing app
(2) 501 opens Phone Appli Pepple then making call to 502
=> Brekeke phone is loaded but the call is not tablished (NG)
Expect: Brekeke phone is loaded but the call is tablished successfully

### 1050
(1) Login UC user A  on device 1
(2) Kill app by system task manage 
(3) Login UC user B on device 2
(4) User B still see user with online status ( NG )