### PR TITLE
Fix issue 1042: It always shows UC connection failed after network is reconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Improve hold pal with pending cache and retry, add toast to show message on android incoming call
 - Fix it should prevent double quickly click hold button (issue 1031)
 - Fix it should save logs when the device is locked (issue 1040)
+- Fix it should not display error message UC connection failure in incoming call (issue 1042)
 - Fix it should not show notification with LPC service (issue 1044)
 - Embed:
   - Disable webphone.resource-line from getProductInfo, allow to set it from embed login instead

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -170,8 +170,7 @@ const initApp = async () => {
   const clearConnectionReaction = reaction(
     () => getConnectionStatus(),
     status => {
-      // UC only logs in when the app is active,
-      // Do not display the message if it is a UC connect failed error on IncomingCallActivity
+      // should not display error message UC connection failure in incoming call
       if (
         status.isFailure &&
         status.message &&

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -170,6 +170,16 @@ const initApp = async () => {
   const clearConnectionReaction = reaction(
     () => getConnectionStatus(),
     status => {
+      // UC only logs in when the app is active,
+      // Do not display the message if it is a UC connect failed error on IncomingCallActivity
+      if (
+        status.isFailure &&
+        status.message &&
+        status.serviceConnectingOrFailure === 'UC'
+      ) {
+        BrekekeUtils.updateConnectionStatus('', false)
+        return
+      }
       BrekekeUtils.updateConnectionStatus(status.message, status.isFailure)
     },
     { fireImmediately: true },

--- a/src/utils/getConnectionStatus.ts
+++ b/src/utils/getConnectionStatus.ts
@@ -31,5 +31,6 @@ export const getConnectionStatus = () => {
     message,
     isFailure,
     onPress: isFailure ? ctx.auth.resetFailureStateIncludePbxOrUc : undefined,
+    serviceConnectingOrFailure,
   }
 }


### PR DESCRIPTION
### Step
(1) Login A to Brekeke phone (Android) then kill app
(2) Turn off network (wifi) then turn on
(3) Make call to A > A answers
=> The call is connected, and it show UC connection failed on top of call screen without dissapearing (NG)