### PR TITLE
Fix issue 1046: Avata is reloaded every times when tapping the buttons on Call screen

### DIFF
--- a/src/components/SmartImage.tsx
+++ b/src/components/SmartImage.tsx
@@ -64,6 +64,15 @@ const getNoCacheUri = (uri: string) => {
   return `${uri}${sep}nocache=${Date.now()}`
 }
 
+// This updates the "no-cache" URI whenever the input `uri` changes.
+const useNoCacheUri = (uri: string) => {
+  const [nocacheUri, setNocacheUri] = useState(getNoCacheUri(uri))
+  useEffect(() => {
+    setNocacheUri(getNoCacheUri(uri))
+  }, [uri])
+  return nocacheUri
+}
+
 export const SmartImage = ({
   uri,
   style,
@@ -129,6 +138,7 @@ export const SmartImage = ({
   const isImageUrl =
     (ctx.auth.phoneappliEnabled() && !incoming) || checkImageUrl(uri)
 
+  const nocacheUri = useNoCacheUri(uri)
   return (
     <View style={[css.image, style]}>
       {!statusImageLoading && (
@@ -157,7 +167,7 @@ export const SmartImage = ({
       ) : (
         <Image
           source={{
-            uri: getNoCacheUri(uri),
+            uri: nocacheUri,
           }}
           style={[css.image, css.full]}
           onError={onImageLoadError}


### PR DESCRIPTION
### Step
(1) Login user A on Android phone, B in anywhere and set avatar UC for A, B
(2) A makes call to B > B answers
(3) A taps on/off the buttons as Speaker/Micro/Hold, ...
=> Issue: Avatar is reloaded every times when tapping the buttons
Expect: It should not reloaded
