### PR TITLE
Fix issue 1052: Video is not load when receiving incoming call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix it should not show notification with LPC service (issue 1044)
 - Fix it should not reload avatar when rerender (issue 1046)
 - Fix it should logout when app is closed from task manager (issue 1050)
+- Fix it should load video in video call (issue 1052)
 
 #### 2.16.3
 

--- a/android/app/src/main/java/com/brekeke/phonedev/activity/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/activity/IncomingCallActivity.java
@@ -43,6 +43,7 @@ import com.brekeke.phonedev.BrekekeUtils;
 import com.brekeke.phonedev.BuildConfig;
 import com.brekeke.phonedev.MainActivity;
 import com.brekeke.phonedev.R;
+import com.brekeke.phonedev.utils.Ctx;
 import com.brekeke.phonedev.utils.Emitter;
 import com.brekeke.phonedev.utils.L;
 import com.brekeke.phonedev.utils.PN;
@@ -599,7 +600,11 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
     if (vWebrtcVideo != null) {
       return;
     }
-    vWebrtcVideo = new WebRTCView(this);
+    var ctx = Ctx.rn();
+    if (ctx == null) {
+      return;
+    }
+    vWebrtcVideo = new WebRTCView(ctx);
     vWebrtcVideo.setLayoutParams(
         new RelativeLayout.LayoutParams(
             RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT));
@@ -643,7 +648,11 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
   }
 
   private WebRTCView createNewRTCView(String streamUrl) {
-    WebRTCView rtcView = new WebRTCView(this);
+    var ctx = Ctx.rn();
+    if (ctx == null) {
+      return null;
+    }
+    WebRTCView rtcView = new WebRTCView(ctx);
     rtcView.setZOrder(1);
     rtcView.setObjectFit("cover");
     rtcView.setStreamURL(streamUrl);


### PR DESCRIPTION
### Step:
(1) 101 logins to Brekeke phone (Android), 102 logins IOS
(2) 102 makes video call to 101 > 101 answers
=> The call is connected but video is not load on call screen of 101 (NG)
(3) 101 turns on Video button
=> 101: Video is not load on call screen (NG)
102: Video loads well