### PR TITLE
Fix issue 1043: Can not connect to sip when server restart tomcat on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix it should handle deeplink while making call from PhoneAppli (issue 1014)
 - Fix it should save logs when the device is locked (issue 1040)
 - Fix it should not display error message UC connection failure in incoming call (issue 1042)
+- Fix it should connect to sip after restart tomcat (issue 1043)
 - Fix it should not show notification with LPC service (issue 1044)
 - Fix it should not reload avatar when rerender (issue 1046)
 - Fix it should logout when app is closed from task manager (issue 1050)

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -469,11 +469,14 @@ export class PBX extends EventEmitter {
       this.clearConnectTimeoutId()
       return r
     }
+    if (!(await isConnected())) {
+      return false
+    }
 
     // in syncPnToken, isMainInstance = false
     // we will not proceed further in that case
     if (!this.isMainInstance) {
-      return isConnected()
+      return true
     }
 
     // check again webphone.pal.param.user
@@ -481,7 +484,6 @@ export class PBX extends EventEmitter {
       // TODO:
       // any function get pbxConfig on this time may get undefined
       ctx.auth.pbxConfig = undefined
-      await isConnected()
       await this.getConfig(true)
       const newPalParamUser = ctx.auth.pbxConfig?.['webphone.pal.param.user']
       if (newPalParamUser !== oldPalParamUser) {
@@ -503,7 +505,7 @@ export class PBX extends EventEmitter {
 
     this.startPingInterval()
 
-    return connected
+    return true
   }
 
   // pal client direct event handlers

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -616,6 +616,9 @@ export class PBX extends EventEmitter {
       this.client.close()
       this.client = undefined
       console.log('PBX PN debug: pbx.client set to null in pbx.disconnect')
+      // In some cases, client.close() does NOT trigger onClose (e.g. server restart),
+      // so we must emit 'connection-stopped' manually if not already emitted.
+      this.emit('connection-stopped')
     }
     this.stopPingInterval()
     this.clearConnectTimeoutId()

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -376,13 +376,13 @@ export class PBX extends EventEmitter {
       resolveFn = r
     })
 
-    // Timeout increased to 15s for Android to handle delayed login callback during Tomcat restart.
-    const timeout = Platform.OS === 'android' ? 15000 : 10000
     const newTimeoutPromise = () => {
       this.clearConnectTimeoutId()
       return new Promise<boolean>(resolve => {
         this.connectTimeoutId = BackgroundTimer.setTimeout(() => {
           resolve(false)
+          resolveFn?.(false)
+          resolveFn = undefined
           console.warn('PAL login connection timed out')
           // fix case already reconnected
           if (client === this.client) {
@@ -390,7 +390,7 @@ export class PBX extends EventEmitter {
           } else {
             client.close()
           }
-        }, timeout)
+        }, 10000)
       })
     }
     const login = new Promise<boolean>((resolve, reject) => {


### PR DESCRIPTION
### Step

(1) A logins to Brekeke phone (Android) then running forground and not lock phone
(2) Restart tomcat
(3) Wait for tomcat is reconnected 
=> On Android phone shows "Connectig to SIP/UC connection failed" (NG)
(4) kill app then opening again
=> It still shows "Connectig to SIP/UC connection failed" (NG)
(5) Logout A from brekeke phone then login again
=> It shows "Logged in from another location as the same phone" (NG)
