### PR TITLE
Fix issue 1018: Call one way voice after the 1st call disconnected while talking and switching to background

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
@@ -171,6 +171,9 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
   }
 
   public static void displayIncomingCall(Map<String, String> m) {
+    if (m == null || m.isEmpty()) {
+      return;
+    }
     // init services if not
     initStaticServices();
     acquireWakeLock();

--- a/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
@@ -501,6 +501,24 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void onOutgoing(String uuid) {
+    if (uuid == null || uuid.isEmpty()) {
+      return;
+    }
+    var m = new HashMap<String, String>();
+    m.put("callkeepUuid", uuid);
+    Call.onOutgoing(m);
+  }
+
+  @ReactMethod
+  public void onHandedOutgoingCall(String uuid) {
+    if (uuid == null || uuid.isEmpty()) {
+      return;
+    }
+    Call.onHandled(uuid);
+  }
+
+  @ReactMethod
   public void onHandedIncomingCall(String pnId) {
     if (pnId == null || pnId.isEmpty()) {
       return;

--- a/android/app/src/main/java/com/brekeke/phonedev/utils/Call.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/utils/Call.java
@@ -1,5 +1,7 @@
 package com.brekeke.phonedev.utils;
 
+import android.os.Handler;
+import android.os.Looper;
 import com.brekeke.phonedev.BrekekeUtils;
 import java.util.LinkedList;
 import java.util.Map;
@@ -56,7 +58,15 @@ public class Call {
     current = pending.poll();
     if (current != null) {
       Emitter.emit("showIncomingCall", new JSONObject(current).toString());
-      BrekekeUtils.displayIncomingCall(current);
+      new Handler(Looper.getMainLooper())
+          .postDelayed(
+              () -> {
+                BrekekeUtils.displayIncomingCall(current);
+              },
+              // To ensure deinitConnection completes before
+              // creating new incoming voice connection
+              // when incoming call is rejected
+              300);
     }
   }
 

--- a/android/app/src/main/java/com/brekeke/phonedev/utils/Call.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/utils/Call.java
@@ -1,8 +1,66 @@
 package com.brekeke.phonedev.utils;
 
-// utils to manage incoming calls
-// see the related part in rn js for reference
+import com.brekeke.phonedev.BrekekeUtils;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+import org.json.JSONObject;
 
 public class Call {
-  // TODO:
+  private static Queue<Map<String, String>> pending;
+  private static Map<String, String> current;
+
+  static {
+    pending = new LinkedList<>();
+    current = null;
+  }
+
+  public static boolean isPnIdInPending(String pnId) {
+    if (pnId == null) return false;
+    for (var p : pending) {
+      if (pnId.equals(p.get("x_pn-id"))) return true;
+    }
+    return false;
+  }
+
+  public static void onIncoming(Map<String, String> m) {
+    if (m == null) {
+      return;
+    }
+    var pnId = m.get("x_pn-id");
+    if (pnId == null) {
+      return;
+    }
+    if ((current != null && pnId.equals(current.get("x_pn-id")))) {
+      return;
+    }
+
+    if (current == null) {
+      current = m;
+      BrekekeUtils.displayIncomingCall(current);
+    } else {
+      pending.add(m);
+    }
+  }
+
+  public static void onHandled(String pnIdOrUuid) {
+    if (current == null || pnIdOrUuid == null) {
+      return;
+    }
+    var uuid = current.get("callkeepUuid");
+    var pnid = current.get("x_pn-id");
+    if (!pnIdOrUuid.equals(uuid) && !pnIdOrUuid.equals(pnid)) {
+      return;
+    }
+
+    current = pending.poll();
+    if (current != null) {
+      Emitter.emit("showIncomingCall", new JSONObject(current).toString());
+      BrekekeUtils.displayIncomingCall(current);
+    }
+  }
+
+  public static Map<String, String> getCurrent() {
+    return current;
+  }
 }

--- a/android/app/src/main/java/com/brekeke/phonedev/utils/Call.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/utils/Call.java
@@ -75,10 +75,11 @@ public class Call {
     current = pending.poll();
     if (current != null) {
       Emitter.emit("showIncomingCall", new JSONObject(current).toString());
+      var c = current;
       new Handler(Looper.getMainLooper())
           .postDelayed(
               () -> {
-                BrekekeUtils.displayIncomingCall(current);
+                BrekekeUtils.displayIncomingCall(c);
               },
               // To ensure deinitConnection completes before
               // creating new incoming voice connection

--- a/android/app/src/main/java/com/brekeke/phonedev/utils/Call.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/utils/Call.java
@@ -5,11 +5,10 @@ import android.os.Looper;
 import com.brekeke.phonedev.BrekekeUtils;
 import java.util.LinkedList;
 import java.util.Map;
-import java.util.Queue;
 import org.json.JSONObject;
 
 public class Call {
-  private static Queue<Map<String, String>> pending;
+  private static LinkedList<Map<String, String>> pending;
   private static Map<String, String> current;
 
   static {
@@ -40,6 +39,24 @@ public class Call {
     if (current == null) {
       current = m;
       BrekekeUtils.displayIncomingCall(current);
+    } else {
+      pending.add(m);
+    }
+  }
+
+  public static void onOutgoing(Map<String, String> m) {
+    if (m == null) {
+      return;
+    }
+    var uuid = m.get("callkeepUuid");
+    if (uuid == null) {
+      return;
+    }
+    if ((current != null && uuid.equals(current.get("callkeepUuid")))) {
+      return;
+    }
+    if (current == null) {
+      current = m;
     } else {
       pending.add(m);
     }

--- a/src/components/CallNotify.tsx
+++ b/src/components/CallNotify.tsx
@@ -8,7 +8,7 @@ import { ButtonIcon } from '#/components/ButtonIcon'
 import { IncomingItem } from '#/components/CallVoicesUI'
 import { RnText, RnTouchableOpacity } from '#/components/Rn'
 import { v } from '#/components/variables'
-import { isWeb } from '#/config'
+import { isAndroid, isWeb } from '#/config'
 import { ctx } from '#/stores/ctx'
 import { intl } from '#/stores/intl'
 import { BackgroundTimer } from '#/utils/BackgroundTimer'
@@ -61,7 +61,9 @@ export const CallNotify = observer(() => {
   // try trigger observer?
   void Object.keys(ctx.call.callkeepMap)
   void ctx.call.calls.map(_ => _.callkeepUuid)
-  const c = ctx.call.getCallInNotify()
+  const c = isAndroid
+    ? ctx.call.getCallInNotifyForAndroid()
+    : ctx.call.getCallInNotify()
   // do not show notify if in page call manage
   if (ctx.call.inPageCallManage || !c) {
     return null
@@ -91,7 +93,7 @@ export const CallNotify = observer(() => {
           <RnText bold>{c.getDisplayName()}</RnText>
           <RnText>
             {intl`Incoming Call`}
-            {n > 0 ? ' (' + intl`${n} in background` + ')' : ''}
+            {!isAndroid && n > 0 ? ' (' + intl`${n} in background` + ')' : ''}
           </RnText>
         </View>
         {!hideHangup && (

--- a/src/pages/PageCallBackgrounds.tsx
+++ b/src/pages/PageCallBackgrounds.tsx
@@ -12,8 +12,8 @@ import { intl } from '#/stores/intl'
 import { Duration } from '#/stores/timerStore'
 
 export const PageCallBackgrounds = observer(() => {
-  const bg = ctx.call.calls.filter(c => c.id !== ctx.call.ongoingCallId)
   const oc = ctx.call.getOngoingCall()
+  const bg = oc ? ctx.call.getBgCalls(oc) : []
   const renderItemCall = (c: Immutable<Call>, isCurrentCall?: boolean) => {
     const icons = [
       mdiPhoneHangup,

--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -539,7 +539,7 @@ class PageCallManage extends Component<{
 
   private renderBtns = () => {
     const { call: c } = this.props
-    const n = ctx.call.calls.filter(_ => _.id !== c.id).length
+    const n = ctx.call.getBgCalls(c).length
     if (c.localVideoEnabled && !this.showButtonsInVideoCall) {
       return null
     }

--- a/src/stores/callStore.ts
+++ b/src/stores/callStore.ts
@@ -985,7 +985,7 @@ export class CallStore {
           timerStore.now - _.createdAt > 1000)
       )
     })
-  getCallInNotifyForAndroid = () => {
+  @action getCallInNotifyForAndroid = () => {
     const calls = this.calls.filter(_ => {
       const k = this.callkeepMap[_.callkeepUuid]
       return (
@@ -1000,6 +1000,17 @@ export class CallStore {
     return calls[0]
   }
 
+  @action getBgCalls = (c: Call) => {
+    let arr = this.calls.filter(x => x.id !== c.id)
+    if (isAndroid) {
+      const incomings = arr.filter(x => x.incoming && !x.answered)
+      if (incomings.length > 1) {
+        const [first] = incomings.sort((a, b) => a.createdAt - b.createdAt)
+        arr = arr.filter(x => !(x.incoming && !x.answered) || x.id === first.id)
+      }
+    }
+    return arr
+  }
   shouldRingInNotify = () => {
     if (isWeb) {
       return true

--- a/src/stores/callStore.ts
+++ b/src/stores/callStore.ts
@@ -290,12 +290,10 @@ export class CallStore {
 
   @action private shouldHandleOutgoing = (uuid: string) => {
     const ca = ctx.auth.getCurrentAccount()
-    if (!isAndroid) {
+    if (!isAndroid || !ca?.pushNotificationEnabled) {
       return
     }
-    if (ca?.pushNotificationEnabled) {
-      BrekekeUtils.onHandedOutgoingCall(uuid)
-    }
+    BrekekeUtils.onHandedOutgoingCall(uuid)
   }
   @action private shouldCreateCallkeepUuid = () => {
     const ca = ctx.auth.getCurrentAccount()
@@ -499,7 +497,11 @@ export class CallStore {
     }
     const hasOtherIncoming =
       isAndroid &&
-      this.calls.some(i => i.incoming && i.pnId !== c.pnId && !i.answered)
+      this.calls.some(
+        i =>
+          (!i.incoming && !i.answered) ||
+          (i.incoming && i.pnId !== c.pnId && !i.answered),
+      )
     if (
       !isWeb &&
       c.incoming &&

--- a/src/stores/callStore.ts
+++ b/src/stores/callStore.ts
@@ -1000,7 +1000,7 @@ export class CallStore {
     return calls[0]
   }
 
-  @action getBgCalls = (c: Call) => {
+  getBgCalls = (c: Call) => {
     let arr = this.calls.filter(x => x.id !== c.id)
     if (isAndroid) {
       const incomings = arr.filter(x => x.incoming && !x.answered)

--- a/src/utils/BrekekeUtils.ts
+++ b/src/utils/BrekekeUtils.ts
@@ -72,7 +72,10 @@ type TBrekekeUtils = {
     d: string,
     t: 'success' | 'error' | 'warning' | 'info',
   ): void
-
+  // Android pending incoming call
+  isPnIdInPending(pnId: string): Promise<boolean>
+  onHandedIncomingCall(pnId: string): void
+  getCurrentIncomingCall(): Promise<string | null>
   // ==========================================================================
   // these methods only available on ios
   webrtcSetAudioEnabled(enabled: boolean): void
@@ -156,7 +159,10 @@ const Polyfill: TBrekekeUtils = {
   updateConnectionStatus: () => undefined,
   updateAnyHoldLoading: () => undefined,
   toast: () => undefined,
-
+  // Android pending incoming call
+  isPnIdInPending: () => Promise.resolve(false),
+  onHandedIncomingCall: () => undefined,
+  getCurrentIncomingCall: () => Promise.resolve(null),
   // ==========================================================================
   // these methods only available on ios
   webrtcSetAudioEnabled: () => undefined,

--- a/src/utils/BrekekeUtils.ts
+++ b/src/utils/BrekekeUtils.ts
@@ -75,7 +75,9 @@ type TBrekekeUtils = {
   // Android pending incoming call
   isPnIdInPending(pnId: string): Promise<boolean>
   onHandedIncomingCall(pnId: string): void
+  onHandedOutgoingCall(uuid: string): void
   getCurrentIncomingCall(): Promise<string | null>
+  onOutgoing(uuid: string): void
   // ==========================================================================
   // these methods only available on ios
   webrtcSetAudioEnabled(enabled: boolean): void
@@ -162,7 +164,10 @@ const Polyfill: TBrekekeUtils = {
   // Android pending incoming call
   isPnIdInPending: () => Promise.resolve(false),
   onHandedIncomingCall: () => undefined,
+  onHandedOutgoingCall: () => undefined,
   getCurrentIncomingCall: () => Promise.resolve(null),
+  onOutgoing: () => undefined,
+
   // ==========================================================================
   // these methods only available on ios
   webrtcSetAudioEnabled: () => undefined,

--- a/src/utils/PushNotification-parse.ts
+++ b/src/utils/PushNotification-parse.ts
@@ -203,6 +203,13 @@ export const parse = async (
     return
   }
 
+  if (isAndroid && (await BrekekeUtils.isPnIdInPending(n.id))) {
+    console.log(
+      `SIP PN debug: PushNotification-parse: PnId ${n.id} is in pending incoming call`,
+    )
+    return
+  }
+
   // handle duplicated pn on android
   // sometimes getInitialNotifications not update callkeepUuid yet
   if (isAndroid && n.callkeepUuid) {

--- a/src/utils/callkeep.ts
+++ b/src/utils/callkeep.ts
@@ -339,6 +339,18 @@ export const setupCallKeepEvents = async () => {
       )
     }
   })
+
+  eventEmitter.addListener('showIncomingCall', (m: string) => {
+    try {
+      parse(JSON.parse(m), false)
+    } catch (err) {
+      console.error(
+        'CallKeep debug: Failed to parse showIncomingCall data:',
+        err,
+      )
+    }
+  })
+
   // other utils
   eventEmitter.addListener('onIncomingCallActivityBackPressed', () => {
     if (!RnStacker.stacks.length) {


### PR DESCRIPTION
2 outgoing calls active

### Step
Answer 2nd call then cancel 1st call
(0) A logins brekeke phone (Android)
(1) B makes 1st call to A
(2) C makes 2nd call to A
(3) A answers 2nd of C
(4) B cancels call with A while A and C are talking
(5) A switches call to background or lock phone
=> The call is still connected with voice good
(6) Wait for 5s
=> C can not hear A talks but A still C talks (NG)
(7) Switch foreground then switching background and repeat step 5
=> The call is connected well when in foreground but one way voice after 5s in background (NG)

**It also happens with Android 12, 13, 14 and ver2.14.10. On ver2.14.10 and and Adroid 13 you have to wait for 75s after switching background/lock phone to reproduce

TODO:
- Hỏi ý kiến của QA xem update lại call flow vào pending như vậy bị thay đổi logic lúc nhận cuộc gọi mà đang có outgoing call thì sẽ bị ẩn đi?