### PR TITLE
Fix issue 1040:  Brekeke Phone does not save logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix android it should open app when press on the running in background notification (issue 1022, 1034)
 - Improve hold pal with pending cache and retry, add toast to show message on android incoming call
 - Fix it should prevent double quickly click hold button (issue 1031)
+- Fix it should save logs when the device is locked (issue 1040)
 - Embed:
   - Disable webphone.resource-line from getProductInfo, allow to set it from embed login instead
   - Add support for setProductName in embed api

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import '#/embed/polyfill'
-import '#/utils/captureConsoleOutput'
 import '#/polyfill'
 import '#/polyfill/mobx-configure'
 import '#/brekekejs/pal'
@@ -7,6 +6,7 @@ import '#/brekekejs/webrtcclient'
 import '#/brekekejs/phonebook'
 import '#/brekekejs/webnotification'
 import '#/stores/ctx-imports'
+import '#/utils/captureConsoleOutput'
 
 import { AppRegistry } from 'react-native'
 


### PR DESCRIPTION
### [Steps]
1. Log in with BrekekePhone.
2. Swipe BrekekePhone from the app list to close.
3. Press the power button to lock the device.
4. BrekekePhone receives a call, answers, makes a call, and ends the call.
5. Open BrekekePhone and send debug logs.