### PR TITLE
Update new logic for custom-page

### DIFF
--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -1185,9 +1185,9 @@ const _parseListCustomPage = () => {
       return
     }
     url = addFromNumberNonce(url)
-    const title = c[`${id}.title`] || intl`PBX user settings`
-    const pos = c[`${id}.pos`] || 'setting,right,1'
-    const incoming = c[`${id}.incoming`]
+    const title = c[`${id}.title`]?.trim() || intl`PBX user settings`
+    const pos = c[`${id}.pos`]?.trim() || 'setting,right,1'
+    const incoming = c[`${id}.incoming`]?.trim()
     results.push({
       id,
       url,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -283,8 +283,6 @@ export const App = observer(() => {
     onPress: onPressConnMessage,
   } = getConnectionStatus()
 
-  const cp = ctx.auth.listCustomPage[0]
-
   return (
     <View style={[StyleSheet.absoluteFill, css.App]} {...getWebRootIdProps()}>
       {ctx.chat.chatNotificationSoundRunning && <AudioPlayer />}
@@ -317,7 +315,11 @@ export const App = observer(() => {
       <View style={css.App_Inner}>
         <RnStackerRoot />
         <RenderAllCalls />
-        {cp && <PageCustomPageView id={cp.id} />}
+        <View>
+          {ctx.auth.listCustomPage.map(cp => (
+            <PageCustomPageView key={cp.id} id={cp.id} />
+          ))}
+        </View>
         <RnPickerRoot />
         <PhonebookAddItem />
         <RnAlertRoot />

--- a/src/components/CustomPageWebView.tsx
+++ b/src/components/CustomPageWebView.tsx
@@ -6,6 +6,7 @@ import type { WebViewNavigationEvent } from 'react-native-webview/lib/WebViewTyp
 
 import { webviewInjectSendJsonToRnOnLoad } from '#/components/webviewInjectSendJsonToRnOnLoad'
 import { buildWebViewSource, isAndroid } from '#/config'
+import { ctx } from '#/stores/ctx'
 
 const css = StyleSheet.create({
   image: {
@@ -90,6 +91,19 @@ export const CustomPageWebView = ({
     }
   }
 
+  const onShouldStartLoadWithRequest = (event: { url: string }) => {
+    const callScheme = 'brekekephone://call?number='
+    const url = event.url
+    if (url.startsWith(callScheme)) {
+      const number = url.slice(callScheme.length)
+      if (number) {
+        ctx.call.startCall(number)
+      }
+      return false
+    }
+    return true
+  }
+
   return (
     <WebView
       source={buildWebViewSource(url)}
@@ -105,6 +119,7 @@ export const CustomPageWebView = ({
       onLoadEnd={onLoadEnd}
       onError={onError}
       cacheEnabled={true}
+      onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
     />
   )
 }

--- a/src/components/HeaderNavigation.tsx
+++ b/src/components/HeaderNavigation.tsx
@@ -1,8 +1,8 @@
 import { observer } from 'mobx-react'
 import type { FC } from 'react'
-import { useCallback } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import type { ViewStyle } from 'react-native'
-import { StyleSheet, View } from 'react-native'
+import { Dimensions, ScrollView, StyleSheet, View } from 'react-native'
 
 import { css as fcss } from '#/components/FooterNavigation'
 import { getSubMenus, getTabs } from '#/components/navigationConfig'
@@ -23,6 +23,11 @@ const css = StyleSheet.create({
     alignItems: 'center',
     borderBottomWidth: 3,
     borderColor: v.borderBg,
+  },
+  BtnWithScroll: {
+    paddingHorizontal: 10,
+    maxWidth: 160,
+    minWidth: 100,
   },
   Btn__active: {
     borderColor: v.colors.primary,
@@ -60,10 +65,54 @@ export const Navigation: FC<{
     ),
     [],
   )
+  const needScroll = !isTab && tabs.length > 4
+  const Container = needScroll ? ScrollView : View
+
+  const scrollRef = useRef<ScrollView>(null)
+  const tabPositions = useRef<Map<string, { x: number; width: number }>>(
+    new Map(),
+  )
+
+  const handleTabLayout = useCallback((tabKey: string, event: any) => {
+    const { x, width } = event.nativeEvent.layout
+    tabPositions.current.set(tabKey, { x, width })
+  }, [])
+
+  const scrollToTab = useCallback(() => {
+    const tabKey = subMenu || ctx.auth.activeCustomPageId
+    if (!tabKey || !(menu === 'settings' && needScroll)) {
+      return
+    }
+    const position = tabPositions.current.get(tabKey)
+    if (!position || !scrollRef.current) {
+      return
+    }
+
+    const screenWidth = Dimensions.get('window').width
+    const leftMargin = screenWidth > 600 ? 80 : 60
+    const rightZone = screenWidth * 0.25
+    let scrollX = Math.max(position.x - leftMargin, 0)
+    if (position.x > screenWidth - rightZone) {
+      scrollX += screenWidth > 600 ? 120 : 80
+    }
+    scrollRef.current.scrollTo({ x: scrollX, animated: false })
+  }, [menu, needScroll, subMenu])
+
+  useEffect(() => {
+    if (ctx.auth.activeCustomPageId) {
+      scrollToTab()
+    }
+  }, [ctx.auth.activeCustomPageId, scrollToTab])
 
   return (
-    <View style={css.Navigation}>
-      {tabs.map(s => {
+    <Container
+      style={css.Navigation}
+      ref={scrollRef}
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={{ flexGrow: 1 }}
+    >
+      {tabs.map((s, idx) => {
         const active = s.key === subMenu
         const totalUnreadChat = ctx.chat.unreadCount
         const totalNoticesWebchat = ctx.chat.getNumberWebchatNoti()
@@ -72,7 +121,12 @@ export const Navigation: FC<{
           <RnTouchableOpacity
             key={s.key}
             onPress={active ? undefined : s.navFn}
-            style={[css.Btn, active && css.Btn__active]}
+            onLayout={event => handleTabLayout(s.key, event)}
+            style={[
+              css.Btn,
+              needScroll && css.BtnWithScroll,
+              active && css.Btn__active,
+            ]}
           >
             <RnText
               small
@@ -91,6 +145,6 @@ export const Navigation: FC<{
           </RnTouchableOpacity>
         )
       })}
-    </View>
+    </Container>
   )
 })

--- a/src/components/navigationConfig.ts
+++ b/src/components/navigationConfig.ts
@@ -1,6 +1,8 @@
 import { action } from 'mobx'
 import type { ReactComponentLike } from 'prop-types'
 
+import { isCustomPageUrlBuilt } from '#/api/customPage'
+import { buildCustomPageUrl } from '#/api/pbx'
 import {
   mdiAccountCircleOutline,
   mdiCogOutline,
@@ -41,14 +43,16 @@ const getSettingSubMenus = (customPages: PbxCustomPage[], isLeft = false) =>
         c.pos.includes(isLeft ? 'left' : 'right') &&
         c.pos.split(',')?.[2],
     )
-    .sort(
-      (a, b) =>
-        parseInt(a.pos.split(',')?.[2]) - parseInt(b.pos.split(',')?.[2]),
-    )
+    .sort((a, b) => {
+      const aOrder = parseInt(a.pos.split(',')?.[2])
+      const bOrder = parseInt(b.pos.split(',')?.[2])
+      return isLeft ? aOrder - bOrder : bOrder - aOrder
+    })
     .map(i => ({ key: i.id, label: i.title, navFnKey: 'goToPageCustomPage' }))
 const genMenus = (customPages: PbxCustomPage[]) => {
   const settingSubMenusLeft = getSettingSubMenus(customPages, true)
   const settingSubMenusRight = getSettingSubMenus(customPages, false)
+
   const settingSubMenus = [
     ...settingSubMenusLeft,
     {
@@ -161,6 +165,25 @@ const genMenus = (customPages: PbxCustomPage[]) => {
             openLinkSafely(urls.phoneappli.HISTORY_CALLED)
             return
           }
+        }
+
+        // should update custom page URL if not built
+        const updateCustomPageUrl = async (i: PbxCustomPage) => {
+          if (isCustomPageUrlBuilt(i.url)) {
+            return
+          }
+          const url = await buildCustomPageUrl(i.url)
+          ctx.auth.updateCustomPage({ ...i, url })
+          ctx.auth.customPageLoadings[i.id] = true
+        }
+
+        if (s.navFnKey === 'goToPageCustomPage') {
+          const cp = ctx.auth.getCustomPageById(s.key)
+          if (!cp) {
+            return
+          }
+          updateCustomPageUrl(cp)
+          ctx.auth.activeCustomPageId = s.key
         }
         // @ts-ignore
         ctx.nav[s.navFnKey]({ id: s.key })

--- a/src/pages/PageCustomPageView.tsx
+++ b/src/pages/PageCustomPageView.tsx
@@ -11,19 +11,31 @@ import {
 import type { PbxCustomPage } from '#/brekekejs'
 import { CustomPageWebView } from '#/components/CustomPageWebView'
 import { Layout } from '#/components/Layout'
+import { RnText } from '#/components/RnText'
 import { ctx } from '#/stores/ctx'
 import { intl } from '#/stores/intl'
 import { RnStacker } from '#/stores/RnStacker'
 
 const css = StyleSheet.create({
   invisible: {
-    top: '-100%',
-    left: '-100%',
+    position: 'absolute',
+    width: 0,
+    height: 0,
+    opacity: 0,
+    overflow: 'hidden',
+  },
+  visible: {
+    position: 'relative',
+    width: '100%',
+    height: '100%',
+    opacity: 1,
   },
 })
 
 @observer
-export class PageCustomPageView extends Component<{ id: string }> {
+export class PageCustomPageView extends Component<{
+  id: string
+}> {
   state = {
     webviewLoading: false,
     webviewError: false,
@@ -93,6 +105,7 @@ export class PageCustomPageView extends Component<{ id: string }> {
         // update stacker flow
         ctx.nav.customPageIndex = ctx.nav.goToPageCustomPage
         ctx.nav.goToPageCustomPage({ id: cp.id })
+        ctx.auth.activeCustomPageId = cp.id
       }
       this.reloadPage(cp)
     }
@@ -106,8 +119,8 @@ export class PageCustomPageView extends Component<{ id: string }> {
       cp &&
       s.isRoot &&
       s.name == 'PageCustomPage' &&
-      RnStacker.stacks.length == 1
-
+      RnStacker.stacks.length == 1 &&
+      cp.id === ctx.auth.activeCustomPageId
     // onLoadEnd not fire with website load image from url camera
     // so, should be check loading like bellow
     const loaded = !this.state.jsLoading || !this.state.webviewLoading
@@ -137,7 +150,7 @@ export class PageCustomPageView extends Component<{ id: string }> {
           },
         ]}
         isFullContent
-        style={isVisible ? undefined : css.invisible}
+        style={isVisible ? css.visible : css.invisible}
       >
         {!!cp?.url && isCustomPageUrlBuilt(cp.url) && (
           <CustomPageWebView

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -131,6 +131,7 @@ export class AuthStore {
   @observable ucConfig?: UcConfig
   @observable pbxConfig?: PbxGetProductInfoRes
   @observable listCustomPage: PbxCustomPage[] = []
+  @observable activeCustomPageId?: string
   saveActionOpenCustomPage = false
   customPageLoadings: { [k: string]: boolean } = {}
   getCustomPageById = (id: string) => this.listCustomPage.find(i => i.id == id)


### PR DESCRIPTION
1. Currently: there is 1 custom page for an incoming call
-> Expect: support 3 custom pages for an incoming call

2. Currently: can not invoke Brekeke Phone from custom page with urls like brekekephone://call?number=
-> Expect: can invoke from custom page
