### PR TITLE
Fix issue 1057: Clearly mumber of keyboard

### DIFF
--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -31,6 +31,7 @@ import {
   isAndroid,
   isEmbed,
   isWeb,
+  RETRY_DELAY,
 } from '#/config'
 import { embedApi } from '#/embed/embedApi'
 import type { Account } from '#/stores/accountStore'
@@ -51,7 +52,6 @@ export class PBX extends EventEmitter {
   private pendingRequests: Request<keyof PbxPal>[] = []
   private requests: Request<keyof PbxPal>[] = []
   private MAX_RETRY = 3
-  private RETRY_DELAY = 300
   @observable retryingRequests: string[] = []
 
   private generateRequestId = (): string => newUuid()
@@ -176,7 +176,7 @@ export class PBX extends EventEmitter {
             request.retryCount++
             setTimeout(() => {
               this.pendingRequests.push(request)
-            }, this.RETRY_DELAY)
+            }, RETRY_DELAY)
           } else {
             request.reject(err)
           }

--- a/src/brekekejs/index.d.ts
+++ b/src/brekekejs/index.d.ts
@@ -431,7 +431,7 @@ export type MakeCallFn = (
   videoEnabled?: boolean,
   videoOptions?: object,
   exInfo?: string,
-) => void
+) => Promise<boolean>
 
 export type VideoOptions = {
   call: {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -25,7 +25,7 @@ import { AudioPlayer, RnStatusBar, RnText } from '#/components/Rn'
 import { RnTouchableOpacity } from '#/components/RnTouchableOpacity'
 import { ToastRoot } from '#/components/ToastRoot'
 import { v } from '#/components/variables'
-import { isEmbed, isIos, isWeb } from '#/config'
+import { DEFAULT_TIMEOUT, isEmbed, isIos, isWeb } from '#/config'
 import { getWebRootIdProps } from '#/embed/polyfill'
 import { RenderAllCalls } from '#/pages/PageCallManage'
 import { PageCustomPageView } from '#/pages/PageCustomPageView'
@@ -84,7 +84,10 @@ const initApp = async () => {
 
   registerOnUnhandledError(unexpectedErr => {
     // must wrap in setTimeout avoid mobx error state change when rendering
-    BackgroundTimer.setTimeout(() => RnAlert.error({ unexpectedErr }), 300)
+    BackgroundTimer.setTimeout(
+      () => RnAlert.error({ unexpectedErr }),
+      DEFAULT_TIMEOUT,
+    )
     return false
   })
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,5 +17,6 @@ export const isIos = Platform.OS === 'ios'
 export const isWeb = Platform.OS === 'web'
 export const isEmbed = isWeb && !window._BrekekePhoneWebRoot
 
-export const btnLoadingTimeout = 700
-// TODO: move all timeout config here
+// timeout
+export const DEFAULT_TIMEOUT = 300 // 0.3 seconds
+export const RETRY_DELAY = 300 // 0.3 seconds

--- a/src/pages/PageCallKeypad.tsx
+++ b/src/pages/PageCallKeypad.tsx
@@ -33,6 +33,13 @@ export class PageCallKeypad extends Component {
       return
     }
     ctx.call.startCall(this.txt)
+    this.clearAll()
+  }
+
+  clearAll = () => {
+    this.txtRef.current?.clear()
+    this.txt = ''
+    this.txtSelection = { start: 0, end: 0 }
   }
 
   render() {

--- a/src/pages/PageCallKeypad.tsx
+++ b/src/pages/PageCallKeypad.tsx
@@ -12,7 +12,6 @@ import { ShowNumber } from '#/components/CallShowNumbers'
 import { Layout } from '#/components/Layout'
 import { ctx } from '#/stores/ctx'
 import { intl, intlDebug } from '#/stores/intl'
-import { keypadEmitter } from '#/stores/keypadEmitter'
 import { RnAlert } from '#/stores/RnAlert'
 import { RnKeyboard } from '#/stores/RnKeyboard'
 
@@ -22,18 +21,10 @@ export class PageCallKeypad extends Component {
   txtRef = createRef<TextInput>()
   txtSelection = { start: 0, end: 0 }
 
-  componentDidMount(): void {
-    keypadEmitter.on('clear-all', this.clearAll)
-  }
-
-  componentWillUnmount(): void {
-    keypadEmitter.off('clear-all')
-  }
-
   showKeyboard = () => {
     this.txtRef.current?.focus()
   }
-  callVoice = () => {
+  callVoice = async () => {
     this.txt = this.txt.trim()
     if (!this.txt) {
       RnAlert.error({
@@ -41,12 +32,11 @@ export class PageCallKeypad extends Component {
       })
       return
     }
-    ctx.call.startCall(this.txt)
-  }
-
-  clearAll = () => {
-    this.txt = ''
-    this.txtSelection = { start: 0, end: 0 }
+    if (await ctx.call.startCall(this.txt)) {
+      // clear text after call
+      this.txt = ''
+      this.txtSelection = { start: 0, end: 0 }
+    }
   }
 
   render() {

--- a/src/pages/PageCallKeypad.tsx
+++ b/src/pages/PageCallKeypad.tsx
@@ -12,6 +12,7 @@ import { ShowNumber } from '#/components/CallShowNumbers'
 import { Layout } from '#/components/Layout'
 import { ctx } from '#/stores/ctx'
 import { intl, intlDebug } from '#/stores/intl'
+import { keypadEmitter } from '#/stores/keypadEmitter'
 import { RnAlert } from '#/stores/RnAlert'
 import { RnKeyboard } from '#/stores/RnKeyboard'
 
@@ -20,6 +21,14 @@ export class PageCallKeypad extends Component {
   @observable txt = ''
   txtRef = createRef<TextInput>()
   txtSelection = { start: 0, end: 0 }
+
+  componentDidMount(): void {
+    keypadEmitter.on('clear-all', this.clearAll)
+  }
+
+  componentWillUnmount(): void {
+    keypadEmitter.off('clear-all')
+  }
 
   showKeyboard = () => {
     this.txtRef.current?.focus()
@@ -33,7 +42,6 @@ export class PageCallKeypad extends Component {
       return
     }
     ctx.call.startCall(this.txt)
-    this.clearAll()
   }
 
   clearAll = () => {

--- a/src/pages/PageCallKeypad.tsx
+++ b/src/pages/PageCallKeypad.tsx
@@ -37,7 +37,6 @@ export class PageCallKeypad extends Component {
   }
 
   clearAll = () => {
-    this.txtRef.current?.clear()
     this.txt = ''
     this.txtSelection = { start: 0, end: 0 }
   }

--- a/src/pages/PageChatDetail.tsx
+++ b/src/pages/PageChatDetail.tsx
@@ -16,7 +16,7 @@ import { ChatInput } from '#/components/FooterChatInput'
 import { Layout } from '#/components/Layout'
 import { RnText, RnTouchableOpacity } from '#/components/Rn'
 import { v } from '#/components/variables'
-import { isWeb } from '#/config'
+import { DEFAULT_TIMEOUT, isWeb } from '#/config'
 import type { ChatFile, ChatMessage } from '#/stores/chatStore'
 import { getPartyName } from '#/stores/contactStore'
 import { ctx } from '#/stores/ctx'
@@ -85,7 +85,7 @@ export class PageChatDetail extends Component<{
       .getBuddyChats(id, { max: numberOfChatsPerLoad })
       .then(chats => {
         ctx.chat.pushMessages(id, chats)
-        BackgroundTimer.setTimeout(this.onContentSizeChange, 300)
+        BackgroundTimer.setTimeout(this.onContentSizeChange, DEFAULT_TIMEOUT)
       })
       .catch((err: Error) => {
         RnAlert.error({

--- a/src/pages/PageChatGroupDetail.tsx
+++ b/src/pages/PageChatGroupDetail.tsx
@@ -18,7 +18,7 @@ import { Layout } from '#/components/Layout'
 import { RnText } from '#/components/RnText'
 import { RnTouchableOpacity } from '#/components/RnTouchableOpacity'
 import { v } from '#/components/variables'
-import { isWeb } from '#/config'
+import { DEFAULT_TIMEOUT, isWeb } from '#/config'
 import type { ChatFile, ChatGroup, ChatMessage } from '#/stores/chatStore'
 import { ctx } from '#/stores/ctx'
 import { intl, intlDebug } from '#/stores/intl'
@@ -88,7 +88,7 @@ export class PageChatGroupDetail extends Component<{
       })
       .then(chats => {
         ctx.chat.pushMessages(groupId, chats)
-        BackgroundTimer.setTimeout(this.onContentSizeChange, 300)
+        BackgroundTimer.setTimeout(this.onContentSizeChange, DEFAULT_TIMEOUT)
       })
       .catch((err: Error) => {
         RnAlert.error({

--- a/src/pages/PageContactEdit.tsx
+++ b/src/pages/PageContactEdit.tsx
@@ -17,6 +17,7 @@ import { RnIcon } from '#/components/RnIcon'
 import { RnText } from '#/components/RnText'
 import { RnTouchableOpacity } from '#/components/RnTouchableOpacity'
 import { SelectionItem } from '#/components/SelectionItem'
+import { DEFAULT_TIMEOUT } from '#/config'
 import { ctx } from '#/stores/ctx'
 import { intl, intlDebug } from '#/stores/intl'
 import { RnAlert } from '#/stores/RnAlert'
@@ -59,7 +60,10 @@ export class PageContactEdit extends Component {
     } else {
       ctx.user.loadPbxBuddyList(true)
     }
-    BackgroundTimer.setTimeout(() => this.setState({ didMount: true }), 300)
+    BackgroundTimer.setTimeout(
+      () => this.setState({ didMount: true }),
+      DEFAULT_TIMEOUT,
+    )
   }
   getDDOptions = (ddIndex: number): DropdownItemProps[] => [
     {

--- a/src/pages/PageContactGroupCreate.tsx
+++ b/src/pages/PageContactGroupCreate.tsx
@@ -8,6 +8,7 @@ import { UserItem } from '#/components/ContactUserItem'
 import { Field } from '#/components/Field'
 import { Layout } from '#/components/Layout'
 import { RnTouchableOpacity } from '#/components/RnTouchableOpacity'
+import { DEFAULT_TIMEOUT } from '#/config'
 import { css } from '#/pages/PageContactEdit'
 import { ctx } from '#/stores/ctx'
 import { intl, intlDebug } from '#/stores/intl'
@@ -24,7 +25,10 @@ export class PageContactGroupCreate extends Component {
     didMount: false,
   }
   componentDidMount = () => {
-    BackgroundTimer.setTimeout(() => this.setState({ didMount: true }), 300)
+    BackgroundTimer.setTimeout(
+      () => this.setState({ didMount: true }),
+      DEFAULT_TIMEOUT,
+    )
   }
 
   render() {

--- a/src/pages/PageContactGroupEdit.tsx
+++ b/src/pages/PageContactGroupEdit.tsx
@@ -8,6 +8,7 @@ import { UserItem } from '#/components/ContactUserItem'
 import { Field } from '#/components/Field'
 import { Layout } from '#/components/Layout'
 import { RnTouchableOpacity } from '#/components/RnTouchableOpacity'
+import { DEFAULT_TIMEOUT } from '#/config'
 import { css } from '#/pages/PageContactEdit'
 import { ctx } from '#/stores/ctx'
 import { intl } from '#/stores/intl'
@@ -29,7 +30,10 @@ export class PageContactGroupEdit extends Component<{
         this.selectedUserItems[u.user_id] = u
       }
     })
-    BackgroundTimer.setTimeout(() => this.setState({ didMount: true }), 300)
+    BackgroundTimer.setTimeout(
+      () => this.setState({ didMount: true }),
+      DEFAULT_TIMEOUT,
+    )
   }
 
   render() {

--- a/src/pages/PageSettingsCurrentAccount.tsx
+++ b/src/pages/PageSettingsCurrentAccount.tsx
@@ -1,6 +1,7 @@
 import { observer } from 'mobx-react'
 
 import { AccountCreateForm } from '#/components/AccountCreateForm'
+import { DEFAULT_TIMEOUT } from '#/config'
 import type { Account } from '#/stores/accountStore'
 import { ctx } from '#/stores/ctx'
 import { intl } from '#/stores/intl'
@@ -21,7 +22,7 @@ export const PageSettingsCurrentAccount = observer(() => (
         onConfirm: () => {
           ctx.account.upsertAccount(p)
           ctx.nav.goToPageAccountSignIn()
-          BackgroundTimer.setTimeout(() => ctx.auth.signIn(p), 300)
+          BackgroundTimer.setTimeout(() => ctx.auth.signIn(p), DEFAULT_TIMEOUT)
         },
         confirmText: intl`SAVE`,
       })

--- a/src/stores/AuthPBX.ts
+++ b/src/stores/AuthPBX.ts
@@ -2,6 +2,7 @@ import { debounce } from 'lodash'
 import type { Lambda } from 'mobx'
 import { action, reaction } from 'mobx'
 
+import { DEFAULT_TIMEOUT } from '#/config'
 import { ctx } from '#/stores/ctx'
 import { waitTimeout } from '#/utils/waitTimeout'
 
@@ -62,7 +63,7 @@ export class AuthPBX {
         }),
       )
   }
-  private authWithCheckDebounced = debounce(this.authWithCheck, 300)
+  private authWithCheckDebounced = debounce(this.authWithCheck, DEFAULT_TIMEOUT)
 }
 
 ctx.authPBX = new AuthPBX()

--- a/src/stores/AuthSIP.ts
+++ b/src/stores/AuthSIP.ts
@@ -5,6 +5,7 @@ import { action, reaction } from 'mobx'
 import type { SipLoginOption } from '#/api/sip'
 import { updatePhoneIndex } from '#/api/updatePhoneIndex'
 import type { PbxGetProductInfoRes } from '#/brekekejs'
+import { DEFAULT_TIMEOUT } from '#/config'
 import { ctx } from '#/stores/ctx'
 import { sipErrorEmitter } from '#/stores/sipErrorEmitter'
 import { jsonSafe } from '#/utils/jsonSafe'
@@ -164,7 +165,7 @@ export class AuthSIP {
       }),
     )
   }
-  private authWithCheckDebounced = debounce(this.authWithCheck, 300)
+  private authWithCheckDebounced = debounce(this.authWithCheck, DEFAULT_TIMEOUT)
 }
 
 ctx.authSIP = new AuthSIP()

--- a/src/stores/AuthUC.ts
+++ b/src/stores/AuthUC.ts
@@ -3,6 +3,7 @@ import type { Lambda } from 'mobx'
 import { action, reaction } from 'mobx'
 
 import { Errors } from '#/brekekejs/ucclient'
+import { DEFAULT_TIMEOUT } from '#/config'
 import type { ChatMessage } from '#/stores/chatStore'
 import { ctx } from '#/stores/ctx'
 import { intlDebug } from '#/stores/intl'
@@ -77,7 +78,7 @@ export class AuthUC {
       }),
     )
   }
-  private authWithCheckDebounced = debounce(this.authWithCheck, 300)
+  private authWithCheckDebounced = debounce(this.authWithCheck, DEFAULT_TIMEOUT)
 
   @action private onConnectionStopped = (e: { code: number }) => {
     ctx.auth.ucState = 'failure'

--- a/src/stores/RnKeyboard.ts
+++ b/src/stores/RnKeyboard.ts
@@ -1,6 +1,7 @@
 import { action, observable } from 'mobx'
 import { Keyboard } from 'react-native'
 
+import { DEFAULT_TIMEOUT } from '#/config'
 import { BackgroundTimer } from '#/utils/BackgroundTimer'
 
 class RnKeyboardStore {
@@ -22,7 +23,7 @@ class RnKeyboardStore {
       this.waitKeyboardTimeoutId = BackgroundTimer.setTimeout(() => {
         this.waitKeyboardTimeoutId = 0
         fn(...args)
-      }, 300)
+      }, DEFAULT_TIMEOUT)
     }
 
   keyboardAnimatingTimeoutId = 0
@@ -36,7 +37,7 @@ class RnKeyboardStore {
         this.keyboardAnimatingTimeoutId = 0
         this.isKeyboardAnimating = false
       }),
-      300,
+      DEFAULT_TIMEOUT,
     )
   }
 }

--- a/src/stores/RnStacker.ts
+++ b/src/stores/RnStacker.ts
@@ -2,6 +2,7 @@ import { action, observable } from 'mobx'
 import type { ReactComponentLike } from 'prop-types'
 import type { SyntheticEvent } from 'react'
 
+import { DEFAULT_TIMEOUT } from '#/config'
 import { ctx } from '#/stores/ctx'
 import { RnKeyboard } from '#/stores/RnKeyboard'
 import { BackgroundTimer } from '#/utils/BackgroundTimer'
@@ -57,7 +58,7 @@ export class RnStackerStore {
           this.stackAnimating = true
           BackgroundTimer.setTimeout(() => {
             this.stackAnimating = false
-          }, 300)
+          }, DEFAULT_TIMEOUT)
         }
         //
         const stack0 = {} as RnStack

--- a/src/stores/callStore.ts
+++ b/src/stores/callStore.ts
@@ -14,6 +14,7 @@ import { Call } from '#/stores/Call'
 import type { CancelRecentPn } from '#/stores/cancelRecentPn'
 import { ctx } from '#/stores/ctx'
 import { intl, intlDebug } from '#/stores/intl'
+import { keypadEmitter } from '#/stores/keypadEmitter'
 import { RnAlert } from '#/stores/RnAlert'
 import { RnAppState } from '#/stores/RnAppState'
 import { RnPicker } from '#/stores/RnPicker'
@@ -627,6 +628,8 @@ export class CallStore {
         await waitTimeout(1000)
       }
       this.setAutoEndCallKeepTimer(uuid)
+      // clear all keypad text
+      keypadEmitter.emit('clear-all')
     }
     const sipCreateSession = () => {
       // do not make call if the callkeep ended

--- a/src/stores/callStore.ts
+++ b/src/stores/callStore.ts
@@ -7,7 +7,7 @@ import { v4 as newUuid } from 'uuid'
 
 import { mdiPhone } from '#/assets/icons'
 import type { MakeCallFn, PbxPhoneappliContact, Session } from '#/brekekejs'
-import { isAndroid, isIos, isWeb } from '#/config'
+import { DEFAULT_TIMEOUT, isAndroid, isIos, isWeb } from '#/config'
 import { addCallHistory } from '#/stores/addCallHistory'
 import type { ConnectionState } from '#/stores/authStore'
 import { Call } from '#/stores/Call'
@@ -727,7 +727,7 @@ export class CallStore {
   }
   private updateBackgroundCallsDebounce = debounce(
     this.updateBackgroundCalls,
-    300,
+    DEFAULT_TIMEOUT,
     { maxWait: 1000 },
   )
   @action private updateCurrentCall = () => {
@@ -744,9 +744,13 @@ export class CallStore {
     }
     this.updateBackgroundCallsDebounce()
   }
-  private updateCurrentCallDebounce = debounce(this.updateCurrentCall, 300, {
-    maxWait: 1000,
-  })
+  private updateCurrentCallDebounce = debounce(
+    this.updateCurrentCall,
+    DEFAULT_TIMEOUT,
+    {
+      maxWait: 1000,
+    },
+  )
 
   // callkeep + pn data
   @observable callkeepMap: {
@@ -1057,7 +1061,7 @@ export class CallStore {
         if (await BrekekeUtils.isLocked()) {
           BrekekeUtils.setIsAppActive(false, true)
         }
-      }, 300)
+      }, DEFAULT_TIMEOUT)
     })
   }
 

--- a/src/stores/debugStore.ts
+++ b/src/stores/debugStore.ts
@@ -9,7 +9,7 @@ import RNFS from 'react-native-fs'
 import Share from 'react-native-share'
 
 import { RnAsyncStorage } from '#/components/Rn'
-import { isAndroid, isIos, isWeb } from '#/config'
+import { DEFAULT_TIMEOUT, isAndroid, isIos, isWeb } from '#/config'
 import { ctx } from '#/stores/ctx'
 import { intl, intlDebug } from '#/stores/intl'
 import { RnAlert } from '#/stores/RnAlert'
@@ -151,7 +151,7 @@ export class DebugStore {
   }
   writeFile = async () => {
     if (this.loading) {
-      BackgroundTimer.setTimeout(this.writeFileBatch, 300)
+      BackgroundTimer.setTimeout(this.writeFileBatch, DEFAULT_TIMEOUT)
       return
     }
     this.loading = true
@@ -187,7 +187,7 @@ export class DebugStore {
       await this.checkAndCreateFile(LOG_DIR, this.createLogFileName())
     }
   }
-  writeFileBatch = debounce(this.writeFile, 300, { maxWait: 1000 })
+  writeFileBatch = debounce(this.writeFile, DEFAULT_TIMEOUT, { maxWait: 1000 })
 
   openLogFile = (file: ReadDirItem) =>
     this.openLogFileWithoutCatch(file).catch((err: Error) => {

--- a/src/stores/keypadEmitter.ts
+++ b/src/stores/keypadEmitter.ts
@@ -1,0 +1,3 @@
+import EventEmitter from 'eventemitter3'
+
+export const keypadEmitter = new EventEmitter()

--- a/src/stores/keypadEmitter.ts
+++ b/src/stores/keypadEmitter.ts
@@ -1,3 +1,0 @@
-import EventEmitter from 'eventemitter3'
-
-export const keypadEmitter = new EventEmitter()

--- a/src/utils/DelayFlag.ts
+++ b/src/utils/DelayFlag.ts
@@ -1,5 +1,6 @@
 import { action, observable } from 'mobx'
 
+import { DEFAULT_TIMEOUT } from '#/config'
 import { BackgroundTimer } from '#/utils/BackgroundTimer'
 
 export class DelayFlag {
@@ -15,7 +16,7 @@ export class DelayFlag {
         this.enabled = !!enabled
         this.timeoutId = 0
       }),
-      300,
+      DEFAULT_TIMEOUT,
     )
   }
 }

--- a/src/utils/waitTimeout.ts
+++ b/src/utils/waitTimeout.ts
@@ -1,6 +1,7 @@
+import { DEFAULT_TIMEOUT } from '#/config'
 import { BackgroundTimer } from '#/utils/BackgroundTimer'
 
-export const waitTimeout = (time = 300) =>
+export const waitTimeout = (time = DEFAULT_TIMEOUT) =>
   new Promise<undefined>(resolve => {
     BackgroundTimer.setTimeout(() => resolve(undefined), time)
   })


### PR DESCRIPTION
### Issue:
when I dial a number using the keypad, the keypad screen remains visible even after the call ends, and the entered number also stays there.
With this behavior, if I put the phone in my pocket immediately after a call or move around while holding it, it often leads to accidental (re-)dialing