### PR TITLE
fix issue: should not reload avatar when the caller toggle mute button

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/activity/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/activity/IncomingCallActivity.java
@@ -1479,6 +1479,9 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
   }
 
   public void setImageTalkingUrl(String url, boolean _isLarge) {
+    if (url.equalsIgnoreCase(talkingAvatar)) {
+      return;
+    }
     talkingAvatar = url;
     isLarge = _isLarge;
     handleShowAvatarTalking();


### PR DESCRIPTION
### Issue:
Image avatar auto reload when the caller toggle mute button