### PR TITLE
Fĩ bug 1031: All buttons are flashed continuously on status bar and call screen when hold button is double click

### DIFF
--- a/src/components/CallBar.tsx
+++ b/src/components/CallBar.tsx
@@ -15,7 +15,7 @@ import {
 import { ButtonIcon } from '#/components/ButtonIcon'
 import { RnIcon, RnText, RnTouchableOpacity } from '#/components/Rn'
 import { v } from '#/components/variables'
-import { isWeb } from '#/config'
+import { holdingTimeout, isWeb } from '#/config'
 import { ctx } from '#/stores/ctx'
 import { intl } from '#/stores/intl'
 import { Duration } from '#/stores/timerStore'
@@ -122,6 +122,7 @@ export const CallBar = observer(() => {
             onPress={oc.toggleHoldWithCheck}
             path={oc.holding ? mdiPlay : mdiPause}
             loading={oc.rqLoadings['hold']}
+            msLoading={holdingTimeout}
           />
         </View>
       </RnTouchableOpacity>

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,3 +19,4 @@ export const isWeb = Platform.OS === 'web'
 // timeout
 export const defaultTimeout = 300 // 0.3 seconds
 export const retryInterval = 300 // 0.3 seconds
+export const holdingTimeout = 500 // 0.5 seconds

--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -39,7 +39,7 @@ import { RnText } from '#/components/RnText'
 import { SmartImage } from '#/components/SmartImage'
 import { v } from '#/components/variables'
 import { VideoPlayer } from '#/components/VideoPlayer'
-import { isAndroid, isWeb } from '#/config'
+import { holdingTimeout, isAndroid, isWeb } from '#/config'
 import { PageCallTransferAttend } from '#/pages/PageCallTransferAttend'
 import type { Call, CallConfigKey } from '#/stores/Call'
 import { ctx } from '#/stores/ctx'
@@ -689,6 +689,7 @@ class PageCallManage extends Component<{
               path={c.holding ? mdiPlayCircle : mdiPauseCircle}
               size={40}
               loading={c.rqLoadings['hold']}
+              msLoading={holdingTimeout}
               textcolor='white'
             />
           )}


### PR DESCRIPTION
All buttons are flashed continuously on status bar and call screen when hold button is double click

![CleanShot 2025-09-18 at 09 45 13](https://github.com/user-attachments/assets/96ad6cdb-ac1c-4693-8f5f-59120aa6cf1c)
