### PR TITLE
Bug 1081: It shows error message on top after every 30s when using PBX 3.16.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix it should crash when add park number (issue 1068)
 - Fix it should show remote video when remote enable (issue 1074)
 - Fix android it should reconnect LPC on internet connection lost (issue 1076)
+- Fix it should not show error on ping failure (issue 1081)
 
 #### 2.16.5
 

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -344,9 +344,9 @@ export class PBX extends EventEmitter {
     if (err === true) {
       return
     }
-    ctx.toast.internet(err)
     if (this.isPalTimeoutError(err)) {
       ctx.authPBX.dispose()
+      ctx.toast.internet()
       // wait for 1 second to ensure PBX is fully stopped and Mobx reactions cleared
       await waitTimeout(1000)
       ctx.authPBX.auth()


### PR DESCRIPTION
### Step
(1) Login brekeke phone on IOS, Android and run forground
(2) Wait 30s and view screen
=>Issues: It shows error message on top with both IOS and Android

**It happens with pbx 3.16.8.0 without 3.17
Check screen shot #1081
<img width="818" height="1226" alt="CleanShot 2025-10-02 at 09 59 52@2x" src="https://github.com/user-attachments/assets/04c2b300-0573-4763-ba9b-98c10e993bf2" />
