### PR TITLE
Bug 1079: PN call screen is cut-off when receiving multi call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix it should crash when add park number (issue 1068)
 - Fix it should show remote video when remote enable (issue 1074)
 - Fix android it should reconnect LPC on internet connection lost (issue 1076)
+- Fix it should not cut off call screen in small screen device (issue 1079)
 - Fix it should not show error on ping failure (issue 1081)
 
 #### 2.16.5

--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -50,7 +50,7 @@ import { checkMutedRemoteUser } from '#/utils/checkMutedRemoteUser'
 import { waitTimeout } from '#/utils/waitTimeout'
 
 const { width, height } = Dimensions.get('window')
-const minSizeH = height * 0.35
+const minSizeH = height * 0.3
 const minSizeW = width * 0.8
 const minSizeImageWrapper = minSizeH > minSizeW ? minSizeW : minSizeH
 

--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -50,8 +50,8 @@ import { checkMutedRemoteUser } from '#/utils/checkMutedRemoteUser'
 import { waitTimeout } from '#/utils/waitTimeout'
 
 const { width, height } = Dimensions.get('window')
-const minSizeH = height * 0.4
-const minSizeW = width * 0.9
+const minSizeH = height * 0.35
+const minSizeW = width * 0.8
 const minSizeImageWrapper = minSizeH > minSizeW ? minSizeW : minSizeH
 
 const css = StyleSheet.create({
@@ -88,7 +88,7 @@ const css = StyleSheet.create({
   Btns_Inner: {
     flexDirection: 'row',
     alignSelf: 'center',
-    width: Dimensions.get('screen').width,
+    width,
     flexWrap: 'wrap',
     justifyContent: 'center',
     alignItems: 'center',
@@ -493,7 +493,7 @@ class PageCallManage extends Component<{
     const isShowAvatar =
       (c.partyImageUrl || c.talkingImageUrl) && !c.localVideoEnabled
     const styleBigAvatar = c.localVideoEnabled
-      ? { flex: 1, maxHeight: Dimensions.get('window').height / 2 - 20 }
+      ? { flex: 1, maxHeight: height / 2 - 20 }
       : { flex: 1 }
     const styleViewAvatar = isLarge ? styleBigAvatar : css.smallAvatar
     return (


### PR DESCRIPTION
### Step:
1) A logins brekeke phone in IOS
(2) B makes call to A > A answer
(3) C makes call to A
=> It shows PN call screen is cut-off (check screenshot #1079

**Device info: Iphone 13, IOS version 18.5
<img width="542" height="1136" alt="CleanShot 2025-10-02 at 10 12 44@2x" src="https://github.com/user-attachments/assets/de56b748-660a-4d4b-b893-e62f88e2a2d7" />
