### PR TITLE
Fix issue 1078,1065,1061,1060,1041: Speaker should work stable 

### DIFF
--- a/ios/BrekekePhone.xcodeproj/project.pbxproj
+++ b/ios/BrekekePhone.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		CB8766C028E83920002261CB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CB8766BF28E83920002261CB /* Assets.xcassets */; };
 		CB8766E128E87C59002261CB /* BrekekeLPCExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 9C972B8C28E1B34C00DD89B4 /* BrekekeLPCExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		CBAD324D29F374A20057D82C /* ding.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = CBAD324C29F374A20057D82C /* ding.mp3 */; };
+		CBFFFD682E9676860081E175 /* AudioSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFFFD672E9676860081E175 /* AudioSessionManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -158,6 +159,7 @@
 		CB2145662AF4EF5D004D2EAA /* Intents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Intents.framework; path = System/Library/Frameworks/Intents.framework; sourceTree = SDKROOT; };
 		CB8766BF28E83920002261CB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		CBAD324C29F374A20057D82C /* ding.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; name = ding.mp3; path = ../src/assets/ding.mp3; sourceTree = "<group>"; };
+		CBFFFD672E9676860081E175 /* AudioSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AudioSessionManager.swift; path = BrekekePhone/AudioSessionManager.swift; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -192,6 +194,7 @@
 				9CF1917528E34BA20048E7A1 /* Bridging-Header.h */,
 				9CF1917628E34BA20048E7A1 /* Bridging-Header.m */,
 				9CF1917728E34BA20048E7A1 /* AppDelegate.swift */,
+				CBFFFD672E9676860081E175 /* AudioSessionManager.swift */,
 				9CF3830028ED909C008FC490 /* BrekekeLPCManager.swift */,
 				9CF1917828E34BA20048E7A1 /* BrekekeUtils.swift */,
 				9C391D932550EEAD00E3924D /* BrekekePhone.entitlements */,
@@ -563,6 +566,7 @@
 				9CF382E428ED8496008FC490 /* Publisher+DropNil.swift in Sources */,
 				9CF382FC28ED908E008FC490 /* Settings.swift in Sources */,
 				9CF382C428ED8495008FC490 /* HeartbeatCoordinator.swift in Sources */,
+				CBFFFD682E9676860081E175 /* AudioSessionManager.swift in Sources */,
 				9CF1917B28E34BA20048E7A1 /* BrekekeUtils.swift in Sources */,
 				9C972BB828E1B5BF00DD89B4 /* BrekekeLPCExtension.swift in Sources */,
 				9CF382EC28ED8496008FC490 /* KeyCodable.swift in Sources */,
@@ -751,10 +755,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -815,10 +816,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = false;

--- a/ios/BrekekePhone/Bridging-Header.m
+++ b/ios/BrekekePhone/Bridging-Header.m
@@ -4,7 +4,9 @@
 #import <React/RCTEventEmitter.h>
 
 @interface RCT_EXTERN_MODULE (BrekekeUtils, NSObject)
-RCT_EXTERN_METHOD(webrtcSetAudioEnabled : (BOOL)enabled)
+RCT_EXTERN_METHOD(webrtcSetAudioEnabled
+                  : (BOOL)enabled action
+                  : (NSString *)action)
 RCT_EXTERN_METHOD(enableLPC
                   : (NSString *)token tokenVoip
                   : (NSString *)tokenVoip username
@@ -15,7 +17,9 @@ RCT_EXTERN_METHOD(enableLPC
                   : (NSString *)localSsid tlsKeyHash
                   : (NSString *)tlsKeyHash)
 RCT_EXTERN_METHOD(disableLPC)
-
+RCT_EXTERN_METHOD(isSpeakerOn
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(playRBT : (BOOL)isLoudSpeaker)
 RCT_EXTERN_METHOD(stopRBT
                   : (RCTPromiseResolveBlock)resolve rejecter

--- a/patches/react-native-callkeep+4.3.16.patch
+++ b/patches/react-native-callkeep+4.3.16.patch
@@ -566,7 +566,7 @@ index c8e7bbd..052f0ac 100644
  + (void)reportNewIncomingCall:(NSString *)uuidString
                         handle:(NSString *)handle
 diff --git a/node_modules/react-native-callkeep/ios/RNCallKeep/RNCallKeep.m b/node_modules/react-native-callkeep/ios/RNCallKeep/RNCallKeep.m
-index 786045f..ced1257 100644
+index 786045f..ec539cd 100644
 --- a/node_modules/react-native-callkeep/ios/RNCallKeep/RNCallKeep.m
 +++ b/node_modules/react-native-callkeep/ios/RNCallKeep/RNCallKeep.m
 @@ -47,7 +47,6 @@ @implementation RNCallKeep
@@ -577,7 +577,15 @@ index 786045f..ced1257 100644
  static CXProvider* sharedProvider;
  
  // should initialise in AppDelegate.m
-@@ -171,24 +170,22 @@ - (void)sendEventWithNameWrapper:(NSString *)name body:(id)body {
+@@ -59,6 +58,7 @@ - (instancetype)init
+     NSLog(@"[RNCallKeep][init]");
+ #endif
+     if (self = [super init]) {
++        _version = [[NSProcessInfo processInfo] operatingSystemVersion];
+         _isStartCallActionEventListenerAdded = NO;
+         _isReachable = NO;
+         if (_delayedEvents == nil) _delayedEvents = [NSMutableArray array];
+@@ -171,24 +171,22 @@ - (void)sendEventWithNameWrapper:(NSString *)name body:(id)body {
              body, @"data",
              nil
          ];
@@ -608,7 +616,7 @@ index 786045f..ced1257 100644
      @try{
          NSArray<AVAudioSessionPortDescription *>* outputs = [AVAudioSession sharedInstance].currentRoute.outputs;
          if(outputs != nil && outputs.count > 0){
-@@ -197,52 +194,9 @@ + (NSString *) getAudioOutput {
+@@ -197,52 +195,9 @@ + (NSString *) getAudioOutput {
      } @catch(NSException* error) {
          NSLog(@"getAudioOutput error :%@", [error description]);
      }
@@ -661,7 +669,7 @@ index 786045f..ced1257 100644
  RCT_EXPORT_METHOD(setReachable)
  {
  #ifdef DEBUG
-@@ -297,21 +251,6 @@ + (void)setup:(NSDictionary *)options {
+@@ -297,21 +252,6 @@ + (void)setup:(NSDictionary *)options {
                            fromPushKit: NO
                                payload: nil
                  withCompletionHandler: nil];
@@ -683,7 +691,7 @@ index 786045f..ced1257 100644
  }
  
  RCT_EXPORT_METHOD(getInitialEvents:(RCTPromiseResolveBlock)resolve
-@@ -339,7 +278,13 @@ + (void)setup:(NSDictionary *)options {
+@@ -339,7 +279,13 @@ + (void)setup:(NSDictionary *)options {
  {
  #ifdef DEBUG
      NSLog(@"[RNCallKeep][startCall] uuidString = %@", uuidString);
@@ -697,7 +705,7 @@ index 786045f..ced1257 100644
      int _handleType = [RNCallKeep getHandleType:handleType];
      NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
      CXHandle *callHandle = [[CXHandle alloc] initWithType:_handleType value:handle];
-@@ -651,17 +596,22 @@ + (NSString *) getAudioInputType: (NSString *) type
+@@ -651,17 +597,22 @@ + (NSString *) getAudioInputType: (NSString *) type
  
  + (NSString *) getSelectedAudioRoute
  {
@@ -730,7 +738,7 @@ index 786045f..ced1257 100644
  }
  
  - (void)requestTransaction:(CXTransaction *)transaction
-@@ -876,37 +826,20 @@ + (int)getHandleType:(NSString *)handleType
+@@ -876,64 +827,74 @@ + (int)getHandleType:(NSString *)handleType
      }
  }
  
@@ -778,24 +786,66 @@ index 786045f..ced1257 100644
      return providerConfiguration;
  }
  
-@@ -916,24 +849,10 @@ - (void)configureAudioSession
-     NSLog(@"[RNCallKeep][configureAudioSession] Activating audio session");
- #endif
- 
+-- (void)configureAudioSession
++- (NSDictionary *)getCallsInfo
+ {
+-#ifdef DEBUG
+-    NSLog(@"[RNCallKeep][configureAudioSession] Activating audio session");
+-#endif
++    CXCallObserver *callObserver = [[CXCallObserver alloc] init];
++    NSArray *calls = callObserver.calls;
+     
 -    NSUInteger categoryOptions = AVAudioSessionCategoryOptionAllowBluetooth | AVAudioSessionCategoryOptionAllowBluetoothA2DP;
 -    NSString *mode = AVAudioSessionModeDefault;
--
++    NSInteger totalCalls = calls.count;
++    NSInteger answeredCalls = 0;
++    NSInteger incomingCalls = 0;
+     
 -    NSDictionary *settings = [RNCallKeep getSettings];
 -    if (settings && settings[@"audioSession"]) {
 -        if (settings[@"audioSession"][@"categoryOptions"]) {
 -            categoryOptions = [settings[@"audioSession"][@"categoryOptions"] integerValue];
--        }
++    for (CXCall *call in calls) {
++        if (call.hasConnected) {
++            answeredCalls++;
+         }
 -
 -        if (settings[@"audioSession"][@"mode"]) {
 -            mode = settings[@"audioSession"][@"mode"];
--        }
--    }
--
++        if (!call.outgoing && !call.hasConnected) {
++            incomingCalls++;
+         }
+     }
+     
++#ifdef DEBUG
++    NSLog(@"[RNCallKeep][getCallsInfo] Total: %ld, Answered: %ld, Incoming: %ld",
++          (long)totalCalls, (long)answeredCalls, (long)incomingCalls);
++#endif
++    
++    return @{
++        @"total": @(totalCalls),
++        @"answered": @(answeredCalls),
++        @"incoming": @(incomingCalls),
++        @"hasActiveCalls": @(totalCalls > 0)
++    };
++}
++
++- (void)configureAudioSession
++{
++#ifdef DEBUG
++   NSLog(@"[RNCallKeep][configureAudioSession] Activating audio session");
++#endif
++    
++    // check calls info
++   NSDictionary *callsInfo = [self getCallsInfo];
++   NSInteger totalCalls = [callsInfo[@"total"] integerValue];
++   NSInteger answeredCalls = [callsInfo[@"answered"] integerValue];
++ 
++   // only configure if there are active calls
++   if (totalCalls > 1) {
++       NSLog(@"[RNCallKeep][configureAudioSession] No active calls, skipping configuration");
++       return;
++   }
      AVAudioSession* audioSession = [AVAudioSession sharedInstance];
 -    [audioSession setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:categoryOptions error:nil];
 +    [audioSession setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionAllowBluetooth | AVAudioSessionCategoryOptionAllowBluetoothA2DP error:nil];
@@ -805,7 +855,7 @@ index 786045f..ced1257 100644
  
      double sampleRate = 44100.0;
      [audioSession setPreferredSampleRate:sampleRate error:nil];
-@@ -969,7 +888,7 @@ + (BOOL)application:(UIApplication *)application
+@@ -969,7 +930,7 @@ + (BOOL)application:(UIApplication *)application
  
  + (BOOL)application:(UIApplication *)application
  continueUserActivity:(NSUserActivity *)userActivity
@@ -814,3 +864,12 @@ index 786045f..ced1257 100644
  {
  #ifdef DEBUG
      NSLog(@"[RNCallKeep][application:continueUserActivity]");
+@@ -1142,7 +1103,7 @@ - (void)provider:(CXProvider *)provider didActivateAudioSession:(AVAudioSession
+     };
+     [[NSNotificationCenter defaultCenter] postNotificationName:AVAudioSessionInterruptionNotification object:nil userInfo:userInfo];
+ 
+-    [self configureAudioSession];
++//    [self configureAudioSession];
+     [self sendEventWithNameWrapper:RNCallKeepDidActivateAudioSession body:nil];
+ }
+ 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -113,6 +113,7 @@ const initApp = async () => {
 
     ctx.auth.resetFailureState()
     ctx.call.onCallKeepAction()
+    ctx.call.updateLoudSpeakerStatus()
     ctx.pbx.ping()
     ctx.pnToken.syncForAllAccounts()
 

--- a/src/components/CallVoicesUI.tsx
+++ b/src/components/CallVoicesUI.tsx
@@ -96,9 +96,6 @@ export class AnsweredItem extends Component<{
 export const IosRBT = (p: { isLoudSpeaker: boolean }) => {
   const stopRingbackAndSyncSpeaker = async () => {
     await BrekekeUtils.stopRBT()
-    // make sure AVAudioSession deactivated
-    await waitTimeout()
-    IncallManager.setForceSpeakerphoneOn(p.isLoudSpeaker)
   }
   useEffect(() => {
     BrekekeUtils.playRBT(p.isLoudSpeaker)

--- a/src/stores/callStore.ts
+++ b/src/stores/callStore.ts
@@ -1089,6 +1089,12 @@ export class CallStore {
 
   // some other fields
   @observable isLoudSpeakerEnabled = false
+
+  @action updateLoudSpeakerStatus = async () => {
+    if (isIos && this.getOngoingCall()) {
+      this.isLoudSpeakerEnabled = await BrekekeUtils.isSpeakerOn()
+    }
+  }
   @action toggleLoudSpeaker = () => {
     if (isWeb) {
       return

--- a/src/utils/BrekekeUtils.ts
+++ b/src/utils/BrekekeUtils.ts
@@ -75,10 +75,11 @@ type TBrekekeUtils = {
 
   // ==========================================================================
   // these methods only available on ios
-  webrtcSetAudioEnabled(enabled: boolean): void
+  webrtcSetAudioEnabled(enabled: boolean, action?: string): void
   playRBT(isLoudSpeaker: boolean): void
   stopRBT(): Promise<void>
   setProximityMonitoring(enabled: boolean): void
+  isSpeakerOn(): Promise<boolean>
 
   // ==========================================================================
   // these methods available on both
@@ -164,7 +165,7 @@ const Polyfill: TBrekekeUtils = {
   playRBT: () => undefined,
   stopRBT: () => Promise.resolve(),
   setProximityMonitoring: () => undefined,
-
+  isSpeakerOn: () => Promise.resolve(false),
   // ==========================================================================
   // these methods available on both
   enableLPC: () => undefined,

--- a/src/utils/callkeep.ts
+++ b/src/utils/callkeep.ts
@@ -166,7 +166,8 @@ export const setupCallKeepEvents = async () => {
     if (c && c.holding !== e.hold) {
       c.toggleHoldWithCheck()
     }
-    BrekekeUtils.webrtcSetAudioEnabled(!e.hold)
+    // Audio enabled state is managed by didActivateAudioSession and didDeactivateAudioSession
+    // BrekekeUtils.webrtcSetAudioEnabled(!e.hold, e.hold ? 'hold' : 'unhold')
   }
   const didPerformDTMFAction = (e: EventsPayload['didPerformDTMFAction']) => {
     const uuid = e.callUUID.toUpperCase()
@@ -190,14 +191,14 @@ export const setupCallKeepEvents = async () => {
       c.isAudioActive = true
       c.partyAnswered && c.setHoldWithoutCallKeep(false)
     }
-    BrekekeUtils.webrtcSetAudioEnabled(true)
+    BrekekeUtils.webrtcSetAudioEnabled(true, 'didActivateAudioSession')
   }
   const didDeactivateAudioSession = (
     e: EventsPayload['didDeactivateAudioSession'],
   ) => {
     // only in ios
     console.log('CallKeep debug: didDeactivateAudioSession')
-    BrekekeUtils.webrtcSetAudioEnabled(false)
+    BrekekeUtils.webrtcSetAudioEnabled(false, 'didDeactivateAudioSession')
     ctx.call.updateBackgroundCalls()
   }
   const didReceiveStartCallAction = async (
@@ -250,12 +251,13 @@ export const setupCallKeepEvents = async () => {
     eventEmitterIos.addListener(
       'onAudioRouteChange',
       ({ isSpeakerOn }: { isSpeakerOn: boolean }) => {
-        const hasCall = ctx.call.calls.some(
-          c => (c.incoming && c.answered) || !c.incoming,
-        )
-        if (hasCall) {
-          ctx.call.isLoudSpeakerEnabled = isSpeakerOn
-        }
+        // already handled in app becoming active event
+        // const hasCall = ctx.call.calls.some(
+        //   c => (c.incoming && c.answered) || !c.incoming,
+        // )
+        // if (hasCall) {
+        //   ctx.call.isLoudSpeakerEnabled = isSpeakerOn
+        // }
       },
     )
     return


### PR DESCRIPTION
### 1041:
When answering an incoming call while the phone is locked, pressing the speaker button on the call screen can sometimes cause the icon's status display to be incorrect. It might show as invalid when it's valid, or valid when it's invalid. When answering an incoming call while the phone is unlocked, the speaker button icon display on the call screen is fine.

### 1060:
(1) A logins on IOS then A makes voice/video call to B
=> It automatically turns on the loud speaker on user A's screen (NG)
(2) B answers
=> it automatically turns off the loud speaker on user A's screen

### 1061:
Case 1: Hold/unhol
(1) A logins on IOS
(2) A and B are talking, A turns on loud speaker on A's call screen
(3) A presses Hold button then pressing UnHold
=> Loud speaker automatically turns off (NG)

Case 2: Receiving call
(1) A logins brekeke phone (IOS)
(2) B makes call to A > A answer
(3) A turns on loud speaker
=> Issue: loud speaker is turn on but after it is automatically turned off

### 1065:
(1) A logins to brekeke phone (IOS) then running forground
(2) B makes call to A > A rings
(3) C sends PN message while A rings
(4) A answers
=> The call is connected without voice (NG)

### 1078:
(1) A logins brekeke phone on IOS then locking phone
(2) B makes call to A > A answers
(3) C makes call to A > A presses [Hold & accept] button and B hears music
Actual: Sometimes the call is no voice (rate 1/5 calls) (NG)
(4) C disconnects call
=> It shows Hold button on A's lock screen
(5) A presses Hold button
=> Actual: The call becomes no voice in both side (NG)
Expect: The call should resume with good voice