### PR TITLE
Bug 1198: display the line picker only if the number matches the pattern from the Pbx

### DIFF
--- a/src/brekekejs/index.d.ts
+++ b/src/brekekejs/index.d.ts
@@ -293,6 +293,7 @@ export type PbxGetProductInfoRes = {
   'webphone.phonebook.personal.editable': string
   'webphone.recents.max': string
   'webphone.resource-line': string
+  'webphone.resource-line.pattern': string
   'webphone.http.useragent.product': string
   'webphone.error_toast.suppress_enabled': string
   'webphone.error_toast.suppress_patterns': string

--- a/src/stores/addCallHistory.ts
+++ b/src/stores/addCallHistory.ts
@@ -114,7 +114,10 @@ export const addCallHistory = async (
   const answeredBy = getUserInfoFromReasons(isTypeCall ? ms : completedBy)
   const line = (isTypeCall && c?.line) || undefined
   // with incoming: If the string includes /, you store only aaa to the log and ignore / and the following string.
-  const lineValue = line?.split('/')?.[0]?.trim() || line?.trim() || undefined
+  const isIncoming = isTypeCall && c.incoming
+  const lineValue = isIncoming
+    ? line?.split('/')?.[0]?.trim() || line?.trim() || undefined
+    : line?.trim() || undefined
   const lineLabel = lineValue
     ? ctx.auth.resourceLines?.find(item => item.value === lineValue)?.key
     : undefined

--- a/src/stores/callStore.ts
+++ b/src/stores/callStore.ts
@@ -30,6 +30,7 @@ import { jsonSafe } from '#/utils/jsonSafe'
 import { encodeParkNumber } from '#/utils/parkNumber'
 import { permForCall } from '#/utils/permissions'
 import type { ParsedPn } from '#/utils/PushNotification-parse'
+import { shouldUseResourceLine } from '#/utils/resourceLineUtils'
 import { waitTimeout } from '#/utils/waitTimeout'
 import {
   webCloseNotification,
@@ -757,11 +758,14 @@ export class CallStore {
       !this.isLineExist(args[0], ctx.auth.resourceLines)
     ) {
       try {
-        const extraHeaders = await this.getExtraHeader(
-          ctx.auth.resourceLines,
-          args[0],
-        )
-        args[0] = { ...args[0], extraHeaders }
+        const pattern = ctx.auth.pbxConfig?.['webphone.resource-line.pattern']
+        if (shouldUseResourceLine(pattern, number)) {
+          const extraHeaders = await this.getExtraHeader(
+            ctx.auth.resourceLines,
+            args[0],
+          )
+          args[0] = { ...args[0], extraHeaders }
+        }
       } catch (err) {
         console.error(err)
         return false

--- a/src/utils/resourceLineUtils.ts
+++ b/src/utils/resourceLineUtils.ts
@@ -1,0 +1,20 @@
+export const shouldUseResourceLine = (
+  l: string | undefined,
+  number: string,
+) => {
+  if (!l) {
+    return true
+  }
+  const p = l.trim()
+  if (p) {
+    try {
+      const regex = new RegExp(p)
+      if (!number || !regex.test(number)) {
+        return false
+      }
+    } catch (err) {
+      console.warn('Invalid resource-line p:', p, err)
+    }
+  }
+  return true
+}


### PR DESCRIPTION
I'd like to confirm the line selection dialing behavior of BrekekePhone.
When I set "webphone.resource-line" and dialed using an external line (resource), the resource name appeared in the call history.

I expected that when I dialed from that history, it would dial using that resource, but the "X-PBX-RPI" header was not included in the INVITE from BrekekePhone.

**New request:**
Regarding the line selection function using "webphone.resource-line," users have inquired about the possibility of displaying the dialog box only when making an external call, as it's annoying to see it every time.