### PR TITLE
Hot fix: Lpc connection with ECDSA encryption, update UI park item, outgoing call with line

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/lpc/LpcUtils.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/lpc/LpcUtils.java
@@ -26,6 +26,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 import javax.net.ssl.*;
 import org.json.JSONObject;
@@ -174,7 +175,11 @@ public class LpcUtils {
                 throw new CertificateException("Empty certificate chain");
               }
               try {
-                byte[] spki = chain[0].getPublicKey().getEncoded();
+                byte[] certDer = chain[0].getEncoded();
+                byte[] spki = extractSPKI(certDer);
+                if (spki == null) {
+                  throw new CertificateException("Failed to extract SPKI from certificate");
+                }
                 byte[] hash = MessageDigest.getInstance("SHA-256").digest(spki);
                 String fingerprint = Base64.encodeToString(hash, Base64.NO_WRAP);
                 if (!fingerprint.equals(sha256Fingerprint)) {
@@ -194,6 +199,58 @@ public class LpcUtils {
 
     sslContext.init(null, trustManagers, null);
     return sslContext;
+  }
+
+  // Extract SubjectPublicKeyInfo (SPKI) from raw certificate DER bytes.
+  // Reads bytes directly from the certificate DER instead of using
+  // getPublicKey().getEncoded(), which may re-encode differently across
+  // Android versions and manufacturers (causing keyhash mismatch on some devices).
+  private static byte[] extractSPKI(byte[] der) {
+    int[] i = {0};
+    if (!enterSequence(der, i)) return null; // Certificate
+    if (!enterSequence(der, i)) return null; // TBSCertificate
+    if (i[0] < der.length && (der[i[0]] & 0xFF) == 0xA0) {
+      if (!skipTLV(der, i)) return null; // version [0] EXPLICIT
+    }
+    if (!skipTLV(der, i)) return null; // serialNumber
+    if (!skipTLV(der, i)) return null; // signature
+    if (!skipTLV(der, i)) return null; // issuer
+    if (!skipTLV(der, i)) return null; // validity
+    if (!skipTLV(der, i)) return null; // subject
+    int spkiStart = i[0];
+    if (i[0] >= der.length || (der[i[0]] & 0xFF) != 0x30) return null;
+    i[0]++;
+    int spkiLen = readLength(der, i);
+    if (spkiLen < 0) return null;
+    int spkiEnd = i[0] + spkiLen;
+    if (spkiEnd > der.length) return null;
+    return Arrays.copyOfRange(der, spkiStart, spkiEnd);
+  }
+
+  private static boolean enterSequence(byte[] der, int[] i) {
+    if (i[0] >= der.length || (der[i[0]] & 0xFF) != 0x30) return false;
+    i[0]++;
+    return readLength(der, i) >= 0;
+  }
+
+  private static boolean skipTLV(byte[] der, int[] i) {
+    if (i[0] >= der.length) return false;
+    i[0]++; // skip tag
+    int len = readLength(der, i);
+    if (len < 0) return false;
+    i[0] += len;
+    return i[0] <= der.length;
+  }
+
+  private static int readLength(byte[] der, int[] i) {
+    if (i[0] >= der.length) return -1;
+    int first = der[i[0]++] & 0xFF;
+    if ((first & 0x80) == 0) return first;
+    int n = first & 0x7F;
+    if (n == 0 || n > 4 || i[0] + n > der.length) return -1;
+    int len = 0;
+    for (int k = 0; k < n; k++) len = (len << 8) | (der[i[0]++] & 0xFF);
+    return len;
   }
 
   public static ArrayList<String> convertReadableArrayToStringList(ReadableArray array) {

--- a/ios/BrekekeLPC/Settings/Settings.swift
+++ b/ios/BrekekeLPC/Settings/Settings.swift
@@ -33,7 +33,8 @@ extension Settings {
 extension Settings.PushManagerSettings {
   /// convenience function that determines if the pushManagerSettings model has
   /// any valid configuration properties set. A valid configuration
-  /// includes both a host value and an SSID or private LTE network configuration
+  /// includes both a host value and an SSID or private LTE network
+  /// configuration
   var isEmpty: Bool {
     if host.isEmpty {
       return true

--- a/src/api/sip.ts
+++ b/src/api/sip.ts
@@ -73,8 +73,12 @@ export class SIP extends EventEmitter {
       const xPbxRpi = extraHeaders.find(header =>
         header.startsWith('X-PBX-RPI:'),
       )
-      const line = m?.getHeader('X-PBX-RPI') || xPbxRpi?.split(':')?.[1]
       const isOutgoing = ev.rtcSession.direction === 'outgoing'
+      // For outgoing calls: prioritize X-PBX-RPI from INVITE request (e.g. gaisen-6261/2)
+      // over 180/183 response (e.g. line/2 from Resource Map) to preserve correct lineValue
+      const line = isOutgoing
+        ? xPbxRpi?.split(':')?.[1] || m?.getHeader('X-PBX-RPI')
+        : m?.getHeader('X-PBX-RPI') || xPbxRpi?.split(':')?.[1]
       const withSDP = isOutgoing && ev.sessionStatus === 'progress' && !!m?.body
       //
       const rawPartyNumber = ev.rtcSession.remote_identity.uri.user

--- a/src/components/ParkItem.tsx
+++ b/src/components/ParkItem.tsx
@@ -1,0 +1,125 @@
+import type { FC } from 'react'
+import { Animated, StyleSheet, View } from 'react-native'
+
+import { RnText, RnTouchableOpacity } from '#/components/Rn'
+import { AnimatedText } from '#/components/RnText'
+import { v } from '#/components/variables'
+import { intl } from '#/stores/intl'
+
+const css = StyleSheet.create({
+  outer: {
+    borderBottomWidth: 1,
+    borderColor: v.borderBg,
+  },
+  inner: {
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+  selectedBg: {
+    backgroundColor: v.colors.primaryFn(0.5),
+  },
+  solidBg: {
+    backgroundColor: v.colors.primary,
+  },
+  subText: {
+    color: v.subColor,
+  },
+})
+
+interface ParkItemProps {
+  index: number
+  name: string
+  parkNumber: string
+  selected: boolean
+  available: boolean
+  // pickup mode only: slot is occupied → show flash animation
+  flashAnim?: Animated.Value
+  onPress: () => void
+}
+
+export const ParkItem: FC<ParkItemProps> = ({
+  index,
+  name,
+  parkNumber,
+  selected,
+  available,
+  flashAnim,
+  onPress,
+}) => {
+  const showAnimation = !!flashAnim
+  const WrapperView: any = showAnimation && !selected ? Animated.View : View
+
+  const flashBg = flashAnim?.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['transparent', v.colors.primaryFn(0.1)],
+  })
+  const flashTextColor = flashAnim?.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['black', 'white'],
+  })
+
+  let wrapperStyle: any
+  let nameTextColor: string | Animated.AnimatedInterpolation<string> | undefined
+
+  if (showAnimation) {
+    if (selected) {
+      wrapperStyle = css.solidBg
+      nameTextColor = 'white'
+    } else {
+      wrapperStyle = { backgroundColor: flashBg }
+      nameTextColor = flashTextColor
+    }
+  } else if (selected) {
+    wrapperStyle = css.selectedBg
+  }
+
+  const displayName = name || intl`<Unnamed>`
+
+  return (
+    <View style={[css.outer, !available && css.disabled]}>
+      <WrapperView style={wrapperStyle}>
+        <RnTouchableOpacity onPress={available ? onPress : undefined}>
+          <View style={css.inner}>
+            {nameTextColor && typeof nameTextColor !== 'string' ? (
+              <AnimatedText
+                bold
+                singleLine
+                style={{ color: nameTextColor as any }}
+              >
+                {displayName}
+              </AnimatedText>
+            ) : (
+              <RnText
+                bold
+                singleLine
+                style={nameTextColor ? { color: nameTextColor } : undefined}
+              >
+                {displayName}
+              </RnText>
+            )}
+            {nameTextColor && typeof nameTextColor !== 'string' ? (
+              <AnimatedText
+                normal
+                small
+                style={{ color: nameTextColor as any }}
+              >
+                {intl`Park number: ` + parkNumber}
+              </AnimatedText>
+            ) : (
+              <RnText
+                normal
+                small
+                style={nameTextColor ? { color: nameTextColor } : css.subText}
+              >
+                {intl`Park number: ` + parkNumber}
+              </RnText>
+            )}
+          </View>
+        </RnTouchableOpacity>
+      </WrapperView>
+    </View>
+  )
+}

--- a/src/components/ParkItem.tsx
+++ b/src/components/ParkItem.tsx
@@ -1,8 +1,9 @@
 import type { FC } from 'react'
 import { Animated, StyleSheet, View } from 'react-native'
 
-import { RnText, RnTouchableOpacity } from '#/components/Rn'
-import { AnimatedText } from '#/components/RnText'
+import { RnTouchableOpacity } from '#/components/Rn'
+import type { TRnText } from '#/components/RnText'
+import { AnimatedText, RnText } from '#/components/RnText'
 import { v } from '#/components/variables'
 import { intl } from '#/stores/intl'
 
@@ -49,77 +50,61 @@ export const ParkItem: FC<ParkItemProps> = ({
   flashAnim,
   onPress,
 }) => {
-  const showAnimation = !!flashAnim
-  const WrapperView: any = showAnimation && !selected ? Animated.View : View
+  const useAnimated = !!flashAnim && !selected
+  const TextComp: TRnText = useAnimated ? AnimatedText : RnText
 
   const flashBg = flashAnim?.interpolate({
     inputRange: [0, 1],
-    outputRange: ['transparent', v.colors.primaryFn(0.1)],
+    outputRange: ['white', v.colors.primary],
   })
   const flashTextColor = flashAnim?.interpolate({
     inputRange: [0, 1],
     outputRange: ['black', 'white'],
   })
 
-  let wrapperStyle: any
-  let nameTextColor: string | Animated.AnimatedInterpolation<string> | undefined
+  let wrapperStyle: Animated.WithAnimatedObject<object> | undefined
+  let textStyle:
+    | { color: string }
+    | { color: Animated.AnimatedInterpolation<string> }
+    | undefined
+  let subTextStyle: typeof textStyle | typeof css.subText
 
-  if (showAnimation) {
-    if (selected) {
-      wrapperStyle = css.solidBg
-      nameTextColor = 'white'
-    } else {
-      wrapperStyle = { backgroundColor: flashBg }
-      nameTextColor = flashTextColor
-    }
+  if (useAnimated) {
+    wrapperStyle = { backgroundColor: flashBg }
+    textStyle = { color: flashTextColor! }
+    subTextStyle = textStyle
+  } else if (selected && flashAnim) {
+    wrapperStyle = css.solidBg
+    textStyle = { color: 'white' }
+    subTextStyle = textStyle
   } else if (selected) {
     wrapperStyle = css.selectedBg
+  } else {
+    subTextStyle = css.subText
   }
 
   const displayName = name || intl`<Unnamed>`
 
+  const content = (
+    <RnTouchableOpacity onPress={available ? onPress : undefined}>
+      <View style={css.inner}>
+        <TextComp bold singleLine style={textStyle as any}>
+          {displayName}
+        </TextComp>
+        <TextComp normal small style={subTextStyle as any}>
+          {intl`Park number: ` + parkNumber}
+        </TextComp>
+      </View>
+    </RnTouchableOpacity>
+  )
+
   return (
     <View style={[css.outer, !available && css.disabled]}>
-      <WrapperView style={wrapperStyle}>
-        <RnTouchableOpacity onPress={available ? onPress : undefined}>
-          <View style={css.inner}>
-            {nameTextColor && typeof nameTextColor !== 'string' ? (
-              <AnimatedText
-                bold
-                singleLine
-                style={{ color: nameTextColor as any }}
-              >
-                {displayName}
-              </AnimatedText>
-            ) : (
-              <RnText
-                bold
-                singleLine
-                style={nameTextColor ? { color: nameTextColor } : undefined}
-              >
-                {displayName}
-              </RnText>
-            )}
-            {nameTextColor && typeof nameTextColor !== 'string' ? (
-              <AnimatedText
-                normal
-                small
-                style={{ color: nameTextColor as any }}
-              >
-                {intl`Park number: ` + parkNumber}
-              </AnimatedText>
-            ) : (
-              <RnText
-                normal
-                small
-                style={nameTextColor ? { color: nameTextColor } : css.subText}
-              >
-                {intl`Park number: ` + parkNumber}
-              </RnText>
-            )}
-          </View>
-        </RnTouchableOpacity>
-      </WrapperView>
+      {useAnimated ? (
+        <Animated.View style={wrapperStyle}>{content}</Animated.View>
+      ) : (
+        <View style={wrapperStyle}>{content}</View>
+      )}
     </View>
   )
 }

--- a/src/pages/PageCallParks.tsx
+++ b/src/pages/PageCallParks.tsx
@@ -1,11 +1,12 @@
 import { uniqBy } from 'lodash'
 import { observer } from 'mobx-react'
 import { Component } from 'react'
+import { Animated } from 'react-native'
 
-import { UserItem } from '#/components/ContactUserItem'
 import { Field } from '#/components/Field'
 import { Layout } from '#/components/Layout'
-import { RnText, RnTouchableOpacity } from '#/components/Rn'
+import { ParkItem } from '#/components/ParkItem'
+import { RnText } from '#/components/Rn'
 import { ctx } from '#/stores/ctx'
 import { intl } from '#/stores/intl'
 
@@ -14,8 +15,29 @@ export class PageCallParks extends Component<{
   ongoing: boolean
 }> {
   prevId?: string
+  flashAnim = new Animated.Value(0)
+  flashLoop = Animated.loop(
+    Animated.sequence([
+      Animated.timing(this.flashAnim, {
+        toValue: 1,
+        duration: 1500,
+        useNativeDriver: false,
+      }),
+      Animated.delay(1000),
+      Animated.timing(this.flashAnim, {
+        toValue: 0,
+        duration: 1000,
+        useNativeDriver: false,
+      }),
+    ]),
+  )
+
   componentDidMount = () => {
+    this.flashLoop.start()
     this.componentDidUpdate()
+  }
+  componentWillUnmount = () => {
+    this.flashLoop.stop()
   }
   componentDidUpdate = () => {
     if (!this.props.ongoing) {
@@ -41,6 +63,7 @@ export class PageCallParks extends Component<{
 
   park = () => {
     const p = this.state.selectedPark
+    this.setState({ selectedPark: '' })
     if (this.props.ongoing) {
       return ctx.call.getOngoingCall()?.park(p)
     }
@@ -63,17 +86,16 @@ export class PageCallParks extends Component<{
     const sp = this.state.selectedPark
     const cp2 = this.props.ongoing
     void ctx.call.getOngoingCall() // trigger componentDidUpdate
-    const isDisable = (parkNumber: string) => {
-      if (cp2) {
-        return !!ctx.call.parkNumbers[parkNumber]
-      }
-      return !ctx.call.parkNumbers[parkNumber]
-    }
+
+    // Only treat selection as active if that slot is still available
+    const selectedOccupied = !!ctx.call.parkNumbers[sp]
+    const selectedAvailable = sp && (cp2 ? !selectedOccupied : selectedOccupied)
+    const effectiveSp = selectedAvailable ? sp : ''
 
     return (
       <Layout
         description={intl`Your park numbers`}
-        fabOnNext={sp && !isDisable(sp) ? this.park : undefined}
+        fabOnNext={effectiveSp ? this.park : undefined}
         fabOnNextText={cp2 ? intl`START PARKING` : intl`CALL PARK`}
         menu={cp2 ? undefined : 'call'}
         onBack={cp2 ? ctx.nav.backToPageCallManage : undefined}
@@ -86,25 +108,28 @@ export class PageCallParks extends Component<{
             <RnText padding>{intl`This account has no park number`}</RnText>
           </>
         )}
-        {parks.map((p, i) => (
-          <RnTouchableOpacity
-            key={i}
-            onPress={() => {
-              if (!isDisable(p.park)) {
-                this.selectPark(p.park)
-              }
-            }}
-          >
-            <UserItem
-              key={i}
-              avatar=''
+        {parks.map((p, i) => {
+          const isOccupied = !!ctx.call.parkNumbers[p.park]
+          // park mode: available when slot is empty
+          // pickup mode: available when slot is occupied
+          const available = cp2 ? !isOccupied : isOccupied
+          return (
+            <ParkItem
+              key={p.park}
+              index={i}
               name={intl`Park` + ` ${i + 1}: ${p.name}`}
-              parkNumber={`${p.park}`}
-              selected={p.park === sp}
-              disabled={isDisable(p.park)}
+              parkNumber={p.park}
+              selected={p.park === effectiveSp}
+              available={available}
+              flashAnim={!cp2 && isOccupied ? this.flashAnim : undefined}
+              onPress={() => {
+                if (available) {
+                  this.selectPark(p.park)
+                }
+              }}
             />
-          </RnTouchableOpacity>
-        ))}
+          )
+        })}
       </Layout>
     )
   }

--- a/src/pages/PageCallParks.tsx
+++ b/src/pages/PageCallParks.tsx
@@ -32,14 +32,18 @@ export class PageCallParks extends Component<{
     ]),
   )
 
+  flashRunning = false
+
   componentDidMount = () => {
-    this.flashLoop.start()
+    this.updateFlashLoop()
     this.componentDidUpdate()
   }
   componentWillUnmount = () => {
     this.flashLoop.stop()
+    this.flashRunning = false
   }
   componentDidUpdate = () => {
+    this.updateFlashLoop()
     if (!this.props.ongoing) {
       return
     }
@@ -48,6 +52,20 @@ export class PageCallParks extends Component<{
       ctx.nav.backToPageCallManage()
     }
     this.prevId = oc?.id
+  }
+
+  // Only run animation when in pickup mode and there are occupied slots
+  updateFlashLoop = () => {
+    const cp2 = this.props.ongoing
+    const hasOccupied = !cp2 && Object.keys(ctx.call.parkNumbers).length > 0
+    if (hasOccupied && !this.flashRunning) {
+      this.flashLoop.start()
+      this.flashRunning = true
+    } else if (!hasOccupied && this.flashRunning) {
+      this.flashLoop.stop()
+      this.flashAnim.setValue(0)
+      this.flashRunning = false
+    }
   }
 
   state = {


### PR DESCRIPTION
### Lpc connection with ECDSA encryption for android

I tried connecting via LPC using BrekekePhoneDev 2.17.1.
On iOS, the connection worked fine using ECDSA, but on Android, it failed.
The following log appears on the PBX side, suggesting a keyhash mismatch.
Android cannot directly extract SPKI from the certificate DER.

### Update animation for park Item 

Regarding the BrekekePhone's park function, on a separate note,
currently, when a call enters the park, the text color of the corresponding park on the park screen changes from gray to black.
Regarding this display, to maintain consistency with other Brekeke products, is it possible to make the background color flash when a call enters the park, as shown in the following video?
A red background color is too harsh for users, so a color that matches the BrekekePhone's design (such as green) would be preferable.
https://drive.google.com/file/d/1-oE6v2e6H48YnaiJhp8uFtx9xuojpfrB/view?usp=drive_link

### Outgoing call with line

When Resource Map is set, PBX returns X-PBX-RPI with resource map 
  key (e.g. "line/2") in 183 response, overwriting the original value 
  from the app (e.g. "gaisen-6261/2")