### PR TITLE
fix: deduplicate incoming call PN on Android when both LPC and FCM are active

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
@@ -51,6 +51,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import org.json.JSONObject;
 
@@ -66,6 +67,13 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
   private static String TAG = "[BrekekeUtils]";
 
   public static WakeLock wl;
+
+  // Dedup incoming call push notifications by pn-id
+  // Both LPC and FCM call onFcmMessageReceived() independently for the same call,
+  // causing duplicate incoming call UI. This map tracks which pn-id has been processed.
+  // Using ConcurrentHashMap because LPC runs on its socket thread while FCM runs on
+  // FirebaseMessagingService thread — both can call onFcmMessageReceived() concurrently.
+  private static final ConcurrentHashMap<String, String> processedPnIds = new ConcurrentHashMap<>();
 
   public static void acquireWakeLock() {
     if (!wl.isHeld()) {
@@ -182,11 +190,18 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
 
   public static void onFcmMessageReceived(Map<String, String> m) {
     // check if it is a PN for incoming call
-    if (PN.id(m) == null) {
+    var pnId = PN.id(m);
+    if (pnId == null) {
+      return;
+    }
+    // skip duplicate: same pn-id already processed from LPC or FCM
+    if (processedPnIds.putIfAbsent(pnId, pnId) != null) {
+      Emitter.debug("onFcmMessageReceived skip duplicate pn-id=" + pnId);
       return;
     }
     if (Account.find(m) == null) {
       Emitter.error("onFcmMessageReceived", "account 404");
+      processedPnIds.remove(pnId);
       return;
     }
     // init services if not
@@ -716,6 +731,14 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
   public void closeAllIncomingCalls() {
     Emitter.debug("closeAllIncomingCalls");
     removeAll();
+  }
+
+  // Clear processed pn-id cache
+  // Called from JS when SIP reconnects or PBX server resets,
+  // because pn-id on the server resets to 1, 2, 3... and old cache would block new calls
+  @ReactMethod
+  public void clearProcessedPnIds() {
+    processedPnIds.clear();
   }
 
   @ReactMethod

--- a/src/utils/BrekekeUtils.ts
+++ b/src/utils/BrekekeUtils.ts
@@ -27,6 +27,7 @@ type TBrekekeUtils = {
   getIncomingCallPendingUserAction(uuid: string): Promise<string>
   closeIncomingCall(uuid: string): void
   closeAllIncomingCalls(): void
+  clearProcessedPnIds(): void
   setPbxConfig(jsonStr: string): void
   setCallConfig(uuid: string, jsonStr: string): void
   setIsAppActive(isAppActive: boolean, isAppActiveLocked: boolean): void
@@ -134,6 +135,7 @@ const Polyfill: TBrekekeUtils = {
   getIncomingCallPendingUserAction: () => Promise.resolve(''),
   closeIncomingCall: () => undefined,
   closeAllIncomingCalls: () => undefined,
+  clearProcessedPnIds: () => undefined,
   setPbxConfig: () => undefined,
   setCallConfig: () => undefined,
   setIsAppActive: () => undefined,

--- a/src/utils/PushNotification-parse.ts
+++ b/src/utils/PushNotification-parse.ts
@@ -188,9 +188,7 @@ let androidAlreadyProccessedPn: { [k: string]: boolean } = {}
 export const resetProcessedPn = () => {
   ctx.call.callkeepActionMap = {}
   androidAlreadyProccessedPn = {}
-  if (isAndroid) {
-    BrekekeUtils.clearProcessedPnIds()
-  }
+  // BrekekeUtils.clearProcessedPnIds()
 }
 
 export const parse = async (

--- a/src/utils/PushNotification-parse.ts
+++ b/src/utils/PushNotification-parse.ts
@@ -188,6 +188,9 @@ let androidAlreadyProccessedPn: { [k: string]: boolean } = {}
 export const resetProcessedPn = () => {
   ctx.call.callkeepActionMap = {}
   androidAlreadyProccessedPn = {}
+  if (isAndroid) {
+    BrekekeUtils.clearProcessedPnIds()
+  }
 }
 
 export const parse = async (


### PR DESCRIPTION
### Issue:
I’m testing the simultaneous use of LPC and Push Gateway in BrekekePhone.
When both are used, the PBX sends push requests to both LPC and Push Gateway.
In the case of BrekekePhone on iOS, push requests are processed in a first-come, first-served manner, and there are no problems.

However, in the case of Android, it seems that both LPC and regular push requests are being processed, resulting in two incoming messages.