### PR TITLE
Fix #1204: detect MFA via 3-tier rule on webphone.pal.mfa flag (BUG-1204)

### DIFF
--- a/src/brekekejs/index.d.ts
+++ b/src/brekekejs/index.d.ts
@@ -312,6 +312,7 @@ export type PbxGetProductInfoRes = {
   'webphone.lpc.pn': string
   'webphone.lpc.port': string
   'webphone.lpc.wifi': string
+  'webphone.pal.mfa'?: string
   'webphone.pal.param.user': string
   'webphone.pn_expires': string
   'webphone.turn.credential': string

--- a/src/utils/mfaUtils.ts
+++ b/src/utils/mfaUtils.ts
@@ -2,11 +2,13 @@ import type { PbxGetProductInfoRes } from '#/brekekejs'
 import { isEmbed } from '#/embed/polyfill'
 import { ctx } from '#/stores/ctx'
 import { compareSemVer } from '#/stores/debugStore'
+import { toBoolean } from '#/utils/string'
 
-// Check if PBX version supports MFA API (>= 3.18).
-// Unlike isMFAEnabled, this does NOT check the global webphone.pal.mfa flag —
-// per-account MFA state is determined by mfa/start returning type=none or type=code/url.
-// Embed mode: skip MFA entirely — host owns UX, no UI surface for OTP modal.
+// Check if MFA flow should be triggered for this PBX.
+// 3-tier decision rule:
+//   1. webphone.pal.mfa explicit (true/false) → trust admin's intent absolutely.
+//   2. webphone.pal.mfa absent → fallback to per-user model (trust mfa/start).
+// Embed mode: always skip — host owns UX.
 export const isMFASupported = (pc?: PbxGetProductInfoRes) => {
   if (isEmbed) {
     return false
@@ -15,5 +17,14 @@ export const isMFASupported = (pc?: PbxGetProductInfoRes) => {
   if (!c) {
     return false
   }
-  return compareSemVer(c.version, '3.18') >= 0
+  if (compareSemVer(c.version, '3.18') < 0) {
+    return false
+  }
+  // Tier 1: explicit flag → trust admin's intent
+  const flag = c['webphone.pal.mfa']
+  if (flag !== undefined) {
+    return toBoolean(flag)
+  }
+  // Tier 2: flag absent → fallback to per-user model (trust mfa/start)
+  return true
 }


### PR DESCRIPTION
- Tier 1: flag explicit (true/false) → trust admin's intent
- Tier 2: flag absent → fallback to mfa/start response