### PR TITLE
Fix #1203, #1209:  autoAnswer 3PCC paging regression on Android

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
@@ -243,6 +243,13 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
               i.putExtra("data", new HashMap<>(m));
               ctx.startActivity(i);
             };
+    if (activitiesSize > 0
+        && activities.isEmpty()
+        && RNCallKeepModule.onShowIncomingCallUiCallbacks.isEmpty()) {
+      Emitter.debug(
+          "onFcmMessageReceived: reset orphaned activitiesSize from " + activitiesSize + " to 0");
+      activitiesSize = 0;
+    }
     if (VoiceConnectionService.currentConnections.size() > 0
         || RNCallKeepModule.onShowIncomingCallUiCallbacks.size() > 0
         || activitiesSize > 0) {

--- a/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
@@ -198,6 +198,8 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
     if (pnId == null) {
       return;
     }
+    // skip default-dialer popup since we have an incoming call (BUG-1203)
+    resultDefaultDialer("Skip during incoming call");
     // dedup by compound key: pn-id + time
     // same call from LPC and FCM has identical pn-id and time
     var time = PN.time(m);
@@ -485,6 +487,14 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
 
     if (dialerCheckState == DialerCheckState.COMPLETED) {
       resolveDefaultDialer("Already checked");
+      return;
+    }
+
+    // skip popup if there's an active call to avoid interrupting call UX (BUG-1203)
+    // use resolveDefaultDialer (not resultDefaultDialer) so state stays IDLE,
+    // allowing popup to fire normally after the call ends
+    if (jsCallsSize > 0 || activitiesSize > 0) {
+      resolveDefaultDialer("Skip during active call");
       return;
     }
 

--- a/android/app/src/main/java/com/brekeke/phonedev/push_notification/BrekekeMessagingService.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/push_notification/BrekekeMessagingService.java
@@ -31,8 +31,6 @@ public class BrekekeMessagingService extends FcmInstanceIdListenerService {
       return;
     }
 
-    // it should close the default dialer permission popup when there is an incoming call
-    BrekekeUtils.resolveDefaultDialer("The call is incoming");
     BrekekeUtils.onFcmMessageReceived(m.getData());
     Emitter.debug("[BrekekeMessagingService] Incoming call started by FCM");
     Emitter.debug(m.getData().toString());

--- a/src/stores/callStore.ts
+++ b/src/stores/callStore.ts
@@ -94,7 +94,7 @@ export class CallStore {
         }
       }
     } else {
-      c = this.getCallKeep(uuid)
+      c = this.getCallKeep(uuid, { includingAnswered: true })
     }
     if (n.sipPn.autoAnswer && c) {
       if (RnAppState.foregroundOnce && AppState.currentState !== 'active') {
@@ -634,8 +634,9 @@ export class CallStore {
       c.rawSession = rawSession
     }
     this.onSipUaCancel({ pnId: c.pnId })
-    if (c.callkeepUuid) {
-      this.endCallKeep(c.callkeepUuid)
+    const uuidToEnd = c.callkeepUuid || this.getUuidFromPnId(c.pnId) || ''
+    if (uuidToEnd) {
+      this.endCallKeep(uuidToEnd)
     }
 
     this.calls = this.calls.filter(c0 => c0.id !== c.id)

--- a/src/stores/callStore.ts
+++ b/src/stores/callStore.ts
@@ -94,7 +94,10 @@ export class CallStore {
         }
       }
     } else {
-      c = this.getCallKeep(uuid, { includingAnswered: true })
+      c = this.getCallKeep(
+        uuid,
+        isAndroid ? { includingAnswered: true } : undefined,
+      )
     }
     if (n.sipPn.autoAnswer && c) {
       if (RnAppState.foregroundOnce && AppState.currentState !== 'active') {
@@ -635,7 +638,12 @@ export class CallStore {
     }
     this.onSipUaCancel({ pnId: c.pnId })
     const uuidToEnd = c.callkeepUuid || this.getUuidFromPnId(c.pnId) || ''
-    if (uuidToEnd) {
+    // safety: skip endCallKeep if uuid now belongs to another active call
+    // (pnId collision after PBX restart, or callkeepUuid reassignment)
+    if (
+      uuidToEnd &&
+      !this.calls.some(o => o.id !== c.id && o.callkeepUuid === uuidToEnd)
+    ) {
       this.endCallKeep(uuidToEnd)
     }
 

--- a/src/stores/callStore.ts
+++ b/src/stores/callStore.ts
@@ -375,10 +375,14 @@ export class CallStore {
         }
       }
 
+      // tied to sessionStatus transition, not to `e.answered` transition,
+      // because `c.answer()` may set e.answered=true before 'connected' arrives
+      if (e.sessionStatus !== 'connected' && p.sessionStatus === 'connected') {
+        BrekekeUtils.onCallConnected(e.callkeepUuid)
+      }
       if (!e.answered && p.answered) {
         e.answerCallKeep()
         p.answeredAt = now
-        BrekekeUtils.onCallConnected(e.callkeepUuid)
         this.prevDisplayingCallId = e.id
         BrekekeUtils.setSpeakerStatus(this.isLoudSpeakerEnabled)
 


### PR DESCRIPTION
### 1203:
Step:
(1) A logins on Android, B on IOS then killing app 
(2) A calls B by sending URL:
https://qavn03.brekeke.com:8443/pbx/3pcc?tenant=nen001&to=102&from=101&page=true&type=1&phone=1
=> A automatically answers and B rings
(3) B answers
=> The call is connected well
(4) Repeat step 2, 3
=> Issue: The call is connected with:
- Brekeke phone app is opened and included default phone (rate 100%)
-"Connecting..." is always shown-on A's screen (sometimes)
(5) Disconnect call and make next calls > A answers
=> It always shows "1 other call is in background" button on call screen (NG)

**It does not happen with 2.16.11, and normally make call


### 1209:
(1) A logins on Android then killing app and run foreground/background in 1st time, B on IOS (or anywhere) and 
(2) A calls B by sending URL:
https://qavn03.brekeke.com:8443/pbx/3pcc?tenant=nen001&to=102&from=101&page=true&type=2&phone=1
=> Issue: A's screen flashs 2 times the call screen  and I see that there is one more background call being displayed.