### PR TITLE
Fix #1205: prevent CXCallAction nil UUID crash on iOS 

### DIFF
--- a/src/stores/callStore.ts
+++ b/src/stores/callStore.ts
@@ -86,7 +86,9 @@ export class CallStore {
         delete this.callkeepMap[del]
         delete this.callkeepActionMap[del]
         delete this.calleeRejectedMap[del]
-        RNCallKeep.endCall(del)
+        if (del) {
+          RNCallKeep.endCall(del)
+        }
         c.callkeepUuid = uuid
         c.bugIosOffPnServer = false
         if (c.answered) {
@@ -106,7 +108,9 @@ export class CallStore {
       if (isIos) {
         c.isAutoAnswer = true
         BackgroundTimer.setTimeout(() => {
-          RNCallKeep.answerIncomingCall(c.callkeepUuid)
+          if (c.callkeepUuid) {
+            RNCallKeep.answerIncomingCall(c.callkeepUuid)
+          }
         }, 2000)
       }
     }
@@ -183,7 +187,7 @@ export class CallStore {
     // CallKit (kill app + wait >2s). setCurrentCallActive was called from background
     // but iOS requires it in the CallKit tap context for proper audio routing.
     const autoAnswered = this.getCallKeep(uuid, { includingAnswered: true })
-    if (autoAnswered?.isAutoAnswer) {
+    if (autoAnswered?.isAutoAnswer && autoAnswered.callkeepUuid) {
       RNCallKeep.setCurrentCallActive(autoAnswered.callkeepUuid)
     }
   }


### PR DESCRIPTION
(1) A logins app on IOS and running foreground
(2) Make call to A
=> It shows error then app is exitted

**it is esier to produced when creating 2 accounts and then making call to 2 accounts.
