### PR TITLE
fix #1210 : detect auto-answer from SIP Call-Info header 

### DIFF
--- a/src/api/sip.ts
+++ b/src/api/sip.ts
@@ -80,6 +80,9 @@ export class SIP extends EventEmitter {
         ? xPbxRpi?.split(':')?.[1] || m?.getHeader('X-PBX-RPI')
         : m?.getHeader('X-PBX-RPI') || xPbxRpi?.split(':')?.[1]
       const withSDP = isOutgoing && ev.sessionStatus === 'progress' && !!m?.body
+      // Mark paging auto-answer (Call-Info: ;answer-after=0) so JS state matches
+      const isCtiAutoAnswer =
+        !isOutgoing && !!m?.getHeader('Call-Info')?.includes('answer-after=0')
       //
       const rawPartyNumber = ev.rtcSession.remote_identity.uri.user
       const partyNumber =
@@ -119,6 +122,7 @@ export class SIP extends EventEmitter {
         sessionStatus: ev.sessionStatus,
         callConfig: getCallConfigFromHeader(m?.getHeader('X-WEBPHONE-CALL')),
         answered: ev.sessionStatus === 'connected',
+        isAutoAnswer: isCtiAutoAnswer || undefined,
         voiceStreamObject: ev.remoteStreamObject,
         withSDP,
         earlyMedia: withSDP ? ev.remoteStreamObject : null,


### PR DESCRIPTION
Step:
(1) 101 logins to Android, 102 logins IOS (102 runs background)
(2) 102 makes call to 101 with URL:
https://qavn03.brekeke.com:8443/pbx/3pcc?tenant=nen001&to=101&from=102&page=true&type=1&phone=1
=> 101 and 102 ring 
(3) 101 picks up call, 102 still rings
=> 101 (callee) can not hear any thing (NG)
Expect: It should hear music on hold
