### PR TITLE
fix: skip authWithCheck during signInByNotification (BUG-1207)

### DIFF
--- a/src/stores/AuthSIP.ts
+++ b/src/stores/AuthSIP.ts
@@ -134,6 +134,17 @@ export class AuthSIP {
   }
 
   @action private authWithCheck = async () => {
+    // BUG-1207: while signInByNotification is mid-transition, dispose() sets
+    // sipState='stopped' and onCallKeepDidDisplayIncomingCall sees that and
+    // schedules a redundant sip.connect. The 2nd connect calls resetProcessedPn
+    // which wipes user actions captured between the two connects. Skip here so
+    // only the App.tsx onAuthUpdate reaction (after signIn completes) drives auth.
+    if (ctx.auth.isSigningInByNotification) {
+      console.log(
+        'SIP PN debug: skip authWithCheck during signInByNotification',
+      )
+      return
+    }
     if (isSipPnExpired(ctx.auth.sipPn)) {
       ctx.auth.sipPn = {}
     }

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -724,7 +724,8 @@ export class AuthStore {
   // callkeep didDisplayIncomingCall can fire for the same call PN. Both
   // lead to 2+ signIn(acc) running concurrently, racing on signedInId
   // pre-clear and PBX reconnect, leaving PBX stuck in "connecting".
-  private isSigningInByNotification = false
+  // Public so AuthSIP.authWithCheck can gate during account transition (BUG-1207).
+  isSigningInByNotification = false
 
   @action signInByNotification = async (n: ParsedPn) => {
     if (this.isSigningInByNotification) {


### PR DESCRIPTION
STEP:
(1) Login acc1 to phone A (Android) then logging out acc1
(2) Add acc2 to phone A then logging in acc2 and run foreground/background
(3) Make call to acc1 and pickup call immediately (<1s) after receiving call
=> Issue: It shows the call screen with "Connecting...) and the call is not connected, it is disconneced after ringer is time out