### PR TITLE
Fix 1125: Drop call with LPC when killing app

### DIFF
--- a/src/stores/accountStore.ts
+++ b/src/stores/accountStore.ts
@@ -726,6 +726,8 @@ export class AccountStore {
 
     // Resuming after call ended — session from previous mfaStart still valid,
     // just re-show the modal without sending another OTP email.
+    // Active-call guard still needed here: this branch returns before reaching
+    // the pre-mfaStart guard below.
     if (this.keySessionMFA) {
       if (ctx.call.calls.length > 0) {
         ctx.account.setMFAPendingAfterCallsId(ca.id)
@@ -733,6 +735,18 @@ export class AccountStore {
       }
       await this.setMFAPending(ca, true)
       ctx.mfa.show(ca.id)
+      return
+    }
+
+    // Defer fresh mfaStart while a call is active. Sending OTP now would expire
+    // before the call ends, and a transient pbx.client (e.g. mid PBX reconnect)
+    // can throw inside mfaStart — the false-result path below would then sign
+    // the user out and BYE the active call.
+    if (ctx.call.calls.length > 0) {
+      console.log(
+        `MFA debug: defer (${ctx.call.calls.length} active call) for ca=${ca.id}`,
+      )
+      ctx.account.setMFAPendingAfterCallsId(ca.id)
       return
     }
 
@@ -751,10 +765,6 @@ export class AccountStore {
     if (typeof result === 'object' && 'error' in result) {
       await this.setMFAPending(ca, true)
       ctx.mfa.show(ca.id, { error: result.error })
-      return
-    }
-    if (ctx.call.calls.length > 0) {
-      ctx.account.setMFAPendingAfterCallsId(ca.id)
       return
     }
     await this.setMFAPending(ca, true)


### PR DESCRIPTION
### Step:
(1) Set webphone.lpc.pn=false
(2) 101 logins on Android (16) and kill app, 102  on IOS (26)
(3) 101 makes call to 102 by URL:
https://qavn03.brekeke.com:8443/pbx/3pcc?tenant=nen001&to=102&from=101&page=true&type=1&phone=1
=> 101 auto answers and 102 ring
(4) 102 answers > the call is connected well > disconnect call
(5) Repeat step 3 for 2-5 times
=> Issues: 101 receives call and drop after some seconds
(6) Open app 
=> Issue: It always shows "Connecting to SIP ..." on top
(7) Relogin 101
=> Issue: It shows "Logged in from another location as the same phone. I must reinstall app or login with other account