### PR TITLE
Add android lpc native debug logs to diagnose LPC disconnect cause

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/lpc/BrekekeLpcSocket.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/lpc/BrekekeLpcSocket.java
@@ -117,25 +117,42 @@ public class BrekekeLpcSocket {
     }
 
     private void handleCallToServer() {
+      Emitter.debug(
+          "[BrekekeLpcSocket] connecting host="
+              + this.settings.host
+              + " port="
+              + this.settings.port
+              + " tlsKeyHash="
+              + this.settings.tlsKeyHash);
       try {
         SSLContext sslContext =
             LpcUtils.createTrustedSSLContext(this.settings.tlsKeyHash, mContext);
         this.createChannel(sslContext);
       } catch (NoSuchAlgorithmException e) {
         Log.d(LpcUtils.TAG, "NoSuchAlgorithmException: " + e.getMessage());
+        Emitter.error("[BrekekeLpcSocket] NoSuchAlgorithmException: " + e.getMessage());
       } catch (KeyManagementException e) {
         Log.d(LpcUtils.TAG, "KeyManagementException: " + e.getMessage());
+        Emitter.error("[BrekekeLpcSocket] KeyManagementException: " + e.getMessage());
       } catch (NetworkOnMainThreadException | GeneralSecurityException e) {
         Log.d(LpcUtils.TAG, "NetworkOnMainThreadException: " + e.getMessage());
+        Emitter.error("[BrekekeLpcSocket] GeneralSecurityException: " + e.getMessage());
       } catch (IOException e) {
         Log.d(LpcUtils.TAG, "IOException: " + e.getMessage());
-        if (e.getMessage().equals("Connection refused")) {
+        if (e.getMessage() != null && e.getMessage().equals("Connection refused")) {
           // stop service
           LpcUtils.LpcCallback.cb.getStateServer(false);
           Emitter.error("[BrekekeLpcSocket] Connection refused");
+        } else {
+          Emitter.error("[BrekekeLpcSocket] IOException: " + e.getMessage());
         }
       } catch (Exception e) {
         Log.d(LpcUtils.TAG, "Exception: " + e.getMessage());
+        Emitter.error(
+            "[BrekekeLpcSocket] Exception: "
+                + e.getClass().getSimpleName()
+                + ": "
+                + e.getMessage());
       }
     }
 

--- a/android/app/src/main/java/com/brekeke/phonedev/lpc/LpcUtils.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/lpc/LpcUtils.java
@@ -10,6 +10,7 @@ import android.os.IBinder;
 import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Log;
+import com.brekeke.phonedev.utils.Emitter;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.ReadableArray;
@@ -169,23 +170,38 @@ public class LpcUtils {
             public void checkServerTrusted(X509Certificate[] chain, String authType)
                 throws CertificateException {
               if (sha256Fingerprint == null || sha256Fingerprint.isEmpty()) {
+                Emitter.debug("[LpcUtils] checkServerTrusted: empty configured hash, skip");
                 return;
               }
               if (chain == null || chain.length == 0) {
+                Emitter.error("[LpcUtils] checkServerTrusted: empty certificate chain");
                 throw new CertificateException("Empty certificate chain");
               }
               try {
                 byte[] certDer = chain[0].getEncoded();
                 byte[] spki = extractSPKI(certDer);
                 if (spki == null) {
+                  Emitter.error(
+                      "[LpcUtils] checkServerTrusted: extractSPKI returned null"
+                          + " (DER parse failed), certLen="
+                          + certDer.length);
                   throw new CertificateException("Failed to extract SPKI from certificate");
                 }
                 byte[] hash = MessageDigest.getInstance("SHA-256").digest(spki);
                 String fingerprint = Base64.encodeToString(hash, Base64.NO_WRAP);
                 if (!fingerprint.equals(sha256Fingerprint)) {
+                  Emitter.error(
+                      "[LpcUtils] checkServerTrusted: fingerprint mismatch"
+                          + " computed="
+                          + fingerprint
+                          + " expected="
+                          + sha256Fingerprint);
                   throw new CertificateException("Certificate fingerprint does not match");
                 }
+                Emitter.debug(
+                    "[LpcUtils] checkServerTrusted: fingerprint match " + fingerprint);
               } catch (NoSuchAlgorithmException e) {
+                Emitter.error("[LpcUtils] checkServerTrusted: SHA-256 not available");
                 throw new CertificateException("SHA-256 not available", e);
               }
             }


### PR DESCRIPTION
Emit native events to JS so they land in the app debug log file:
- BrekekeLpcSocket.handleCallToServer: log connecting host/port/keyhash and every exception path (NoSuchAlgorithm, KeyManagement, IO, generic).
- LpcUtils.checkServerTrusted: log empty hash skip, empty chain, extractSPKI null, fingerprint mismatch (computed vs expected), match success, and SHA-256 unavailable.

Also harden BrekekeLpcSocket IOException branch against null e.getMessage() to avoid NPE when "Connection refused" comparison runs.