### PR TITLE
fix(android): reconnect LPC socket with new account params on account switch

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
@@ -990,15 +990,17 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
     var i =
         LpcUtils.putConfigToIntent(
             host, port, token, username, tlsKeyHash, r, new Intent(ctx, BrekekeLpcService.class));
-    // BUG-1230: only startForegroundService when the service isn't already running. If the app
-    // is relaunched (e.g. tapping a chat push) while the LPC foreground service survived, calling
-    // startForegroundService again would go through onStartCommand -> startForeground and re-post
-    // the FGS notification the user may have swiped away. bindService refreshes the connection
-    // (onBind) without re-posting the notification.
-    if (!BrekekeLpcService.isServiceStarted) {
+    // Only startForegroundService when the service isn't already running. If the app is
+    // relaunched while the LPC foreground service survived, calling startForegroundService again
+    // would go through onStartCommand -> startForeground and re-post the notification. When the
+    // service is alive, update its config directly so account/phone switches replace the socket
+    // without touching the foreground notification.
+    if (BrekekeLpcService.updateRunningConfig(i)) {
+      Emitter.debug("BrekekeLpcService config updated while running");
+    } else {
       ctx.startForegroundService(i);
+      ctx.bindService(i, LpcUtils.connection, BrekekeLpcService.BIND_AUTO_CREATE);
     }
-    ctx.bindService(i, LpcUtils.connection, BrekekeLpcService.BIND_AUTO_CREATE);
     // update the status if the server turns lpc on or off
     if (LpcUtils.LpcCallback.cb == null) {
       LpcUtils.LpcCallback.setLpcCallback(

--- a/android/app/src/main/java/com/brekeke/phonedev/lpc/BrekekeLpcService.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/lpc/BrekekeLpcService.java
@@ -31,8 +31,10 @@ import java.util.concurrent.Executors;
 // main lpc service
 
 public class BrekekeLpcService extends Service {
-  public static boolean isServiceStarted = false;
-  public static Intent iService;
+  // volatile: written from RN thread (updateConfig/enableLPC) and read from main thread
+  // (watchdog reconnectSocket) and executor thread (socket loop isServiceStarted check)
+  public static volatile boolean isServiceStarted = false;
+  public static volatile Intent iService;
   private static volatile BrekekeLpcService runningService;
   private static ConnectivityManager cm;
   private ConnectivityManager.NetworkCallback networkCallback;

--- a/android/app/src/main/java/com/brekeke/phonedev/lpc/BrekekeLpcService.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/lpc/BrekekeLpcService.java
@@ -24,6 +24,7 @@ import com.brekeke.phonedev.utils.MonitorConnection;
 import com.facebook.react.ReactApplication;
 import com.google.gson.Gson;
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
@@ -32,6 +33,7 @@ import java.util.concurrent.Executors;
 public class BrekekeLpcService extends Service {
   public static boolean isServiceStarted = false;
   public static Intent iService;
+  private static volatile BrekekeLpcService runningService;
   private static ConnectivityManager cm;
   private ConnectivityManager.NetworkCallback networkCallback;
   public static Boolean isReconnectByNetworkChange = false;
@@ -51,6 +53,7 @@ public class BrekekeLpcService extends Service {
     con = new MonitorConnection();
     // BUG-1230: watchdog reconnects the socket in-process instead of restarting the FGS
     con.setReconnectListener(this::reconnectSocket);
+    runningService = this;
   }
 
   @Override
@@ -142,11 +145,45 @@ public class BrekekeLpcService extends Service {
     startInService(iService);
   }
 
+  // Called from enableLPC when the service is already running to update config and reconnect the
+  // socket without going through startForegroundService (which would re-post the notification and
+  // regress BUG-1230). Returns false if the service is not running so the caller falls back to the
+  // normal startForegroundService + bindService first-start path.
+  //
+  // If the intent carries the same config as the live socket (same-account app relaunch, e.g.
+  // tapping a notification), skip the reconnect entirely so the working socket is not interrupted.
+  public static boolean updateRunningConfig(Intent intent) {
+    BrekekeLpcService service = runningService;
+    if (service == null) {
+      return false;
+    }
+    if (iService != null
+        && Objects.equals(iService.getStringExtra("host"), intent.getStringExtra("host"))
+        && iService.getIntExtra("port", 0) == intent.getIntExtra("port", 0)
+        && Objects.equals(iService.getStringExtra("username"), intent.getStringExtra("username"))
+        && Objects.equals(iService.getStringExtra("token"), intent.getStringExtra("token"))
+        && Objects.equals(
+            iService.getStringExtra("tlsKeyHash"), intent.getStringExtra("tlsKeyHash"))) {
+      Emitter.debug("[BrekekeLpcService] Same config, skipping reconnect");
+      return true;
+    }
+    service.updateConfig(intent);
+    return true;
+  }
+
+  private void updateConfig(Intent intent) {
+    isServiceStarted = true;
+    Emitter.debug(
+        "[BrekekeLpcService] Update service config while running username="
+            + intent.getStringExtra("username"));
+    startInService(intent);
+    con.onConnected();
+  }
+
   @Nullable
   @Override
   public IBinder onBind(Intent intent) {
     Log.d(LpcUtils.TAG, "onBind: execute");
-    iService = intent;
     registerNetworkCallback();
     Emitter.debug("[BrekekeLpcService] Start service when bind");
     startInService(intent);
@@ -155,6 +192,7 @@ public class BrekekeLpcService extends Service {
   }
 
   private void startInService(Intent intent) {
+    iService = intent;
     String tlsKeyHash = intent.getStringExtra("tlsKeyHash");
     int port = intent.getIntExtra("port", 0);
     String host = intent.getStringExtra("host");
@@ -177,6 +215,9 @@ public class BrekekeLpcService extends Service {
   @Override
   public void onDestroy() {
     isServiceStarted = false;
+    if (runningService == this) {
+      runningService = null;
+    }
     // BUG-1230: explicitly cancel the socket (it may be parked in select() and would not
     // notice isServiceStarted=false on its own)
     if (currentSocketTask != null) {

--- a/android/app/src/main/java/com/brekeke/phonedev/lpc/BrekekeLpcSocket.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/lpc/BrekekeLpcSocket.java
@@ -161,7 +161,9 @@ public class BrekekeLpcSocket {
         Log.d(LpcUtils.TAG, "IOException: " + e.getMessage());
         if (e.getMessage() != null && e.getMessage().equals("Connection refused")) {
           // stop service
-          LpcUtils.LpcCallback.cb.getStateServer(false);
+          if (LpcUtils.LpcCallback.cb != null) {
+            LpcUtils.LpcCallback.cb.getStateServer(false);
+          }
           Emitter.error("[BrekekeLpcSocket] Connection refused");
         } else {
           Emitter.error("[BrekekeLpcSocket] IOException: " + e.getMessage());
@@ -372,7 +374,9 @@ public class BrekekeLpcSocket {
     }
 
     private Boolean isChatMessage(Map<String, String> m) {
-      return m.get("x_pn-id") == null && "message".equalsIgnoreCase(m.get("event"));
+      // check both x_pn-id and pn-id: server may omit the x_ prefix on some versions
+      return m.get("x_pn-id") == null && m.get("pn-id") == null
+          && "message".equalsIgnoreCase(m.get("event"));
     }
 
     private void handleChatmessageResponse(JSONObject obj, Map<String, String> m) {

--- a/src/utils/PushNotification-parse.ts
+++ b/src/utils/PushNotification-parse.ts
@@ -4,7 +4,6 @@ import { isAndroid, isIos } from '#/config'
 import { ctx } from '#/stores/ctx'
 import { BrekekeUtils } from '#/utils/BrekekeUtils'
 import { openLinkSafely, urls } from '#/utils/deeplink'
-import { jsonStable } from '#/utils/jsonStable'
 import { get } from '#/utils/lodash'
 import { PushNotification } from '#/utils/PushNotification'
 import { toBoolean } from '#/utils/string'
@@ -205,17 +204,19 @@ export const parse = async (
     return
   }
 
-  // handle duplicated pn on android
-  // sometimes getInitialNotifications not update callkeepUuid yet or Event NotificationOpened triggered get more than once
-  if (isAndroid) {
-    const k = n.id || jsonStable(raw)
-    if (androidAlreadyProccessedPn[k]) {
+  // Dedupe call PNs on Android: getInitialNotifications may re-deliver the same call PN, or
+  // NotificationOpened fires more than once for the same tap. Only dedupe when n.id exists
+  // (call PN with pn-id). Chat/local notifications must NOT be deduped here — a user tapping
+  // the same chat notification twice should always navigate, and applying jsonStable(raw) as a
+  // fallback key was causing the first tap to permanently block subsequent chat taps (BUG-1238).
+  if (isAndroid && n.id) {
+    if (androidAlreadyProccessedPn[n.id]) {
       console.log(
-        `SIP PN debug: PushNotification-parse: already processed k=${k}`,
+        `SIP PN debug: PushNotification-parse: already processed pnId=${n.id}`,
       )
       return
     }
-    androidAlreadyProccessedPn[k] = true
+    androidAlreadyProccessedPn[n.id] = true
   }
 
   const acc = await ctx.sip.checkAndRemovePnTokenViaSip(n)

--- a/src/utils/PushNotification.android.ts
+++ b/src/utils/PushNotification.android.ts
@@ -13,7 +13,7 @@ import { ctx } from '#/stores/ctx'
 import { intl } from '#/stores/intl'
 import { BrekekeUtils } from '#/utils/BrekekeUtils'
 import { permNotifications } from '#/utils/permissions'
-import { parse } from '#/utils/PushNotification-parse'
+import { parse, parseNotificationData } from '#/utils/PushNotification-parse'
 
 let fcmTokenFn: Function | undefined = undefined
 const fcmToken = new Promise<string>(resolve => {
@@ -44,8 +44,11 @@ const onNotification = async (
 ) => {
   try {
     await initApp()
-    // flush initial notification
-    if (!n0?.callkeepUuid) {
+    // Only flush the native initialNotifications cache for call PNs that haven't received a
+    // callkeepUuid yet (i.e. payload has pn-id but no callkeepUuid). Chat/local notifications
+    // must NOT trigger this flush — doing so replays old call PNs through signInByNotification
+    // and can block or misdirect the chat account-switch navigation (BUG-1238).
+    if (!n0?.callkeepUuid && parseNotificationData(n0)?.id) {
       getInitialNotifications().then(ns =>
         ns.forEach(n => onNotification(n, initApp)),
       )


### PR DESCRIPTION
When enableLPC() was called while the LPC foreground service was already
running, only bindService() was called. Android does not invoke onBind()
again for an already-bound ServiceConnection (LpcUtils.connection is a
static object), so the updated host/token/username for the newly selected
account were silently ignored — the LPC socket kept running with the old
account's credentials and push notifications stopped arriving.

Fix: add a static volatile `runningService` reference set in onCreate()
and cleared in onDestroy(). Add static `updateRunningConfig(Intent)` which
directly calls `updateConfig` on the live service instance — this updates
iService, writes the new config to disk, and replaces the socket via the
existing createConnection() path, all without touching startForegroundService
or the foreground notification (preserves BUG-1230 behavior). On first start,
updateRunningConfig returns false and the original startForegroundService +
bindService path is taken.

Skip reconnect when config is identical (same host/port/username/token/
tlsKeyHash) so that same-account app relaunches (e.g. tapping a chat
notification while LPC is already live) do not interrupt the working socket.

Also moves `iService = intent` into startInService() so every call site
(onBind, updateConfig, reconnectSocket, reconnectLPC) consistently keeps
iService in sync with the latest config.

Closes: BUG-1237

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019TZduwTyEdrsFGrGQywfL3