### PR TITLE
2.18 - add aiphone.nursecall.enable integration

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/BrekekeUtils.java
@@ -103,6 +103,7 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
   public static boolean isAppActiveLocked = false;
   public static boolean firstShowCallAppActive = false;
   public static boolean phoneappliEnabled = false;
+  public static boolean aiphoneNurseCallEnabled = false;
   public static String userAgentConfig = null;
 
   BrekekeUtils(ReactApplicationContext ctx) {
@@ -809,11 +810,12 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void setTalkingAvatar(String uuid, String url, boolean isLarge) {
+  public void setTalkingAvatar(
+      String uuid, String url, boolean isLarge, String urlInfo, String hc) {
     UiThreadUtil.runOnUiThread(
         () -> {
           try {
-            at(uuid).setImageTalkingUrl(url, isLarge);
+            at(uuid).setImageTalkingUrl(url, isLarge, urlInfo, hc);
           } catch (Exception e) {
           }
         });
@@ -911,6 +913,11 @@ public class BrekekeUtils extends ReactContextBaseJavaModule {
   @ReactMethod
   public void setPhoneappliEnabled(Boolean isEnabled) {
     phoneappliEnabled = isEnabled;
+  }
+
+  @ReactMethod
+  public void setAiphoneNurseCallEnabled(Boolean isEnabled) {
+    aiphoneNurseCallEnabled = isEnabled;
   }
 
   @ReactMethod

--- a/android/app/src/main/java/com/brekeke/phonedev/activity/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/activity/IncomingCallActivity.java
@@ -901,6 +901,9 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
   public boolean hasManuallyToggledCallManageControls = false;
   public boolean isCallManageControlsHidden = false;
   public boolean isAvatarTalkingLoaded = false;
+  // aiphone nurse-call AppToWeb I/F data (passed down from JS via setTalkingAvatar)
+  public String aiphoneUrlInfo = "";
+  public String aiphoneHc = "";
 
   public void toggleCallManageControls() {
     if (isCallManageControlsHidden) {
@@ -1052,12 +1055,31 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
               super.onPageFinished(view, url);
               vWebViewAvatarTalkingLoading.setVisibility(View.GONE);
               isAvatarTalkingLoaded = true;
+              if (BrekekeUtils.aiphoneNurseCallEnabled
+                  && aiphoneUrlInfo != null
+                  && !aiphoneUrlInfo.isEmpty()) {
+                view.evaluateJavascript(
+                    "try{window.updatePhoneState&&window.updatePhoneState("
+                        + org.json.JSONObject.quote(aiphoneUrlInfo)
+                        + ","
+                        + org.json.JSONObject.quote(aiphoneHc == null ? "" : aiphoneHc)
+                        + ",2,0)}catch(e){}",
+                    null);
+              }
             }
 
             @Override
             public void onPageStarted(WebView view, String url, Bitmap favicon) {
               super.onPageStarted(view, url, favicon);
               vWebViewAvatarTalkingLoading.setVisibility(View.VISIBLE);
+              if (BrekekeUtils.aiphoneNurseCallEnabled) {
+                view.evaluateJavascript(
+                    "window.WebInterface = window.WebInterface || {"
+                        + " display10key:function(){}, displayPhoneControl:function(){},"
+                        + " updateUrlString:function(){}, callMainPage:function(){},"
+                        + " closePhoneControl:function(){} };",
+                    null);
+              }
             }
           });
       if (!isAvatarTalkingLoaded) {
@@ -1480,7 +1502,9 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
     btnSpeaker.setSelected(isSpeakerOn);
   }
 
-  public void setImageTalkingUrl(String url, boolean _isLarge) {
+  public void setImageTalkingUrl(String url, boolean _isLarge, String urlInfo, String hc) {
+    aiphoneUrlInfo = urlInfo == null ? "" : urlInfo;
+    aiphoneHc = hc == null ? "" : hc;
     if (url.equalsIgnoreCase(talkingAvatar)) {
       return;
     }

--- a/src/api/pbx.ts
+++ b/src/api/pbx.ts
@@ -1228,6 +1228,7 @@ export class PBX extends EventEmitter {
         'pnumber',
         'language',
         'phoneappli.enable',
+        'aiphone.nursecall.enable',
       ],
     })
 
@@ -1261,6 +1262,7 @@ export class PBX extends EventEmitter {
       phones,
       language: lang,
       phoneappli: toBoolean(res?.[7]),
+      aiphoneNurseCall: toBoolean(res?.[8]),
     }
   }
 

--- a/src/api/sip.ts
+++ b/src/api/sip.ts
@@ -129,6 +129,7 @@ export class SIP extends EventEmitter {
         partyImageUrl: m?.getHeader('X-PBX-IMAGE-RINGING'),
         talkingImageUrl: m?.getHeader('X-PBX-IMAGE-TALKING'),
         partyImageSize: m?.getHeader('X-PBX-IMAGE-SIZE'),
+        urlInfo: m?.getHeader('X-URL-Info'),
         pbxTenant: arr?.[0],
         pbxRoomId: arr?.[1],
         pbxTalkerId: arr?.[2],

--- a/src/api/updatePhoneIndex.ts
+++ b/src/api/updatePhoneIndex.ts
@@ -35,6 +35,7 @@ export const handlePhoneAppli = async extProps => {
   const paEnabled = extProps.phoneappli
   if (d) {
     d.phoneappliEnabled = paEnabled
+    d.aiphoneNurseCallEnabled = extProps.aiphoneNurseCall
     ctx.account.updateAccountData(d)
   }
 

--- a/src/components/SmartImage.tsx
+++ b/src/components/SmartImage.tsx
@@ -53,6 +53,9 @@ function sendJsonToRn(json) {
 
 ${webviewInjectSendJsonToRnOnLoad()}
 `
+// Aiphone nurse-call WebToApp I/F: no-op stubs so the content's WebInterface.* calls
+// don't fall back to its own dummy. Injected before content load when the feature is on.
+const stubJs = `window.WebInterface = { display10key(){}, displayPhoneControl(){}, updateUrlString(){}, callMainPage(){}, closePhoneControl(){} };`
 enum StatusImage {
   loading = 0,
   loaded = 1,
@@ -68,19 +71,39 @@ export const SmartImage = ({
   uri,
   style,
   incoming,
+  urlInfo,
 }: {
   uri: string
   style: object
   incoming: boolean
+  urlInfo?: string
 }) => {
   const [statusImageLoading, setStatusImageLoading] = useState(
     StatusImage.loading,
   )
   const cUrl = useRef(uri)
+  const webviewRef = useRef<WebView>(null)
+  const firedRef = useRef(false)
   useEffect(() => {
     setStatusImageLoading(0)
-    console.log(`SmartImage url=${uri}`)
+    firedRef.current = false
   }, [uri])
+  const aiphoneOn = ctx.auth.aiphoneNurseCallEnabled()
+  useEffect(() => {
+    if (
+      !aiphoneOn ||
+      !urlInfo ||
+      statusImageLoading !== StatusImage.loaded ||
+      firedRef.current
+    ) {
+      return
+    }
+    firedRef.current = true
+    const hc = ctx.auth.getCurrentAccount()?.pbxUsername ?? ''
+    webviewRef.current?.injectJavaScript(
+      `try { window.updatePhoneState && window.updatePhoneState(${JSON.stringify(urlInfo)}, ${JSON.stringify(hc)}, 2, 0); } catch (e) {} true;`,
+    )
+  }, [aiphoneOn, urlInfo, statusImageLoading])
 
   const onMessage = (event: WebViewMessageEvent) => {
     try {
@@ -142,9 +165,12 @@ export const SmartImage = ({
       )}
       {!uri ? null : !isImageUrl ? (
         <WebView
+          ref={webviewRef}
           source={{ uri }}
           injectedJavaScript={js}
-          injectedJavaScriptBeforeContentLoaded={isAndroid ? js : ''}
+          injectedJavaScriptBeforeContentLoaded={
+            (aiphoneOn ? stubJs : '') + (isAndroid ? js : '')
+          }
           style={[css.image, css.full]}
           bounces={false}
           onLoadStart={onLoadStart}

--- a/src/pages/PageCallManage.tsx
+++ b/src/pages/PageCallManage.tsx
@@ -517,15 +517,16 @@ class PageCallManage extends Component<{
         >
           {c.answered && (
             <SmartImage
-              key={c.talkingImageUrl}
+              key={`talking-${c.talkingImageUrl}`}
               uri={`${c.talkingImageUrl}`}
               style={{ flex: 1, aspectRatio: 1 }}
               incoming={c.incoming}
+              urlInfo={c.urlInfo}
             />
           )}
           {!c.answered && (
             <SmartImage
-              key={c.partyImageUrl}
+              key={`ringing-${c.partyImageUrl}`}
               uri={`${c.partyImageUrl}`}
               style={{ flex: 1, aspectRatio: 1 }}
               incoming={c.incoming}

--- a/src/stores/Call.ts
+++ b/src/stores/Call.ts
@@ -43,6 +43,7 @@ export class Call {
   @observable partyImageUrl = ''
   @observable partyImageSize = ''
   @observable talkingImageUrl = ''
+  @observable urlInfo = ''
   @observable partyName = ''
   @observable pbxTenant = ''
   @observable pbxRoomId = ''

--- a/src/stores/accountStore.ts
+++ b/src/stores/accountStore.ts
@@ -94,6 +94,7 @@ export type AccountData = {
   userAgent?: string
   pnExpires?: string
   phoneappliEnabled?: boolean
+  aiphoneNurseCallEnabled?: boolean
   mfa?: MFAInfo
 }
 

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -252,6 +252,7 @@ export class AuthStore {
     )
     console.log(`signIn debug: account ${a.pbxUsername} signed in`)
     BrekekeUtils.setPhoneappliEnabled(!!this.phoneappliEnabled())
+    BrekekeUtils.setAiphoneNurseCallEnabled(!!this.aiphoneNurseCallEnabled())
     if (!autoSignIn) {
       await saveLastSignedInId(getAccountUniqueId(a))
     }
@@ -806,11 +807,16 @@ export class AuthStore {
     !isWeb &&
     (this.userExtensionProperties?.phoneappli ||
       ctx.auth.getCurrentData()?.phoneappliEnabled)
+  aiphoneNurseCallEnabled = () =>
+    !isWeb &&
+    (this.userExtensionProperties?.aiphoneNurseCall ||
+      ctx.auth.getCurrentData()?.aiphoneNurseCallEnabled)
   userExtensionProperties: null | {
     id: string
     name: string
     language: string
     phoneappli: boolean
+    aiphoneNurseCall: boolean
     phones: {
       id: string
       type: string

--- a/src/stores/callStore.ts
+++ b/src/stores/callStore.ts
@@ -335,6 +335,8 @@ export class CallStore {
       c.callkeepUuid,
       c.talkingImageUrl,
       c.partyImageSize === 'large',
+      c.urlInfo,
+      ctx.auth.getCurrentAccount()?.pbxUsername ?? '',
     )
   }
   @action private upsertCall = async (
@@ -458,6 +460,8 @@ export class CallStore {
           e.callkeepUuid,
           e.talkingImageUrl,
           e.partyImageSize === 'large',
+          e.urlInfo,
+          ctx.auth.getCurrentAccount()?.pbxUsername ?? '',
         )
       }
 

--- a/src/utils/BrekekeUtils.ts
+++ b/src/utils/BrekekeUtils.ts
@@ -31,7 +31,13 @@ type TBrekekeUtils = {
   setPbxConfig(jsonStr: string): void
   setCallConfig(uuid: string, jsonStr: string): void
   setIsAppActive(isAppActive: boolean, isAppActiveLocked: boolean): void
-  setTalkingAvatar(uuid: string, url: string, isLarge: boolean): void
+  setTalkingAvatar(
+    uuid: string,
+    url: string,
+    isLarge: boolean,
+    urlInfo: string,
+    hc: string,
+  ): void
   setJsCallsSize(n: number): void
   setRecordingStatus(uuid: string, recording: boolean): void
   setIsVideoCall(uuid: string, isVideoCall: boolean, isMuted: boolean): void
@@ -40,6 +46,7 @@ type TBrekekeUtils = {
   setSpeakerStatus(isSpeakerOn: boolean): void
   setLocale(locale: string): void
   setPhoneappliEnabled(enabled: boolean): void
+  setAiphoneNurseCallEnabled(enabled: boolean): void
   onCallConnected(uuid: string): void
   onCallKeepAction(uuid: string, action: TCallKeepAction): void
   onPageCallManage(uuid: string): void
@@ -148,6 +155,7 @@ const Polyfill: TBrekekeUtils = {
   setSpeakerStatus: () => undefined,
   setLocale: () => undefined,
   setPhoneappliEnabled: () => undefined,
+  setAiphoneNurseCallEnabled: () => undefined,
   onCallConnected: () => undefined,
   onCallKeepAction: () => undefined,
   onPageCallManage: () => undefined,

--- a/src/utils/callkeep.ts
+++ b/src/utils/callkeep.ts
@@ -325,6 +325,8 @@ export const setupCallKeepEvents = async () => {
           uuid,
           c.talkingImageUrl,
           c.partyImageSize === 'large',
+          c.urlInfo,
+          ctx.auth.getCurrentAccount()?.pbxUsername ?? '',
         )
         await waitTimeout(17)
       }


### PR DESCRIPTION
Requirements
① Decide whether nurse call integration is active
Determine Aiphone nurse call integration on/off from the PBX user property aiphone.nursecall.enable (true = integrate, false = don't). The property may not exist, so if no value can be read, default to "not integrated."
② Content display
The content URL is delivered as before — via the Push data field (x_image) and the INVITE / 200 OK headers (X-PBX-IMAGE-RINGING, X-PBX-IMAGE-TALKING). Display whatever comes through those.
③ Content → App (WebView) interface — dummy stubs
The nurse call content includes these WebToApp JavaScript functions. You won't use their functionality, but you can't stop the content from calling them, so implement them as no-op dummy functions that do nothing and return normally:
   • WebInterface.display10key(String msg, String num, String bkColor, Boolean controlDisable)
   • WebInterface.displayPhoneControl(String num, String msg1, String msg2, String msg3, Boolean controlDisable, Boolean autoClose)
   • WebInterface.updateUrlString(String url)
   • WebInterface.callMainPage()
   • WebInterface.closePhoneControl()
Only do this when integration is on (aiphone.nursecall.enable = true).
④ App (WebView) → Content interface — call on answer The content includes this AppToWeb function; call it when a nurse call incoming call is answered:
   • updatePhoneState(String url, String hc, int state, int stateOption)
       • url: value of the received X-URL-Info header; empty string if not received
       • hc: your own extension number (user)
       • state: fixed at 2
       • stateOption: fixed at 0
Conditions: only when integration is on, and only call it when the INVITE actually contained an X-URL-Info header — not on every answered call.