### PR TITLE
2.18 - support webphone.webview.log option to forward webview logs and errors to debug log file

### DIFF
--- a/android/app/src/main/java/com/brekeke/phonedev/activity/IncomingCallActivity.java
+++ b/android/app/src/main/java/com/brekeke/phonedev/activity/IncomingCallActivity.java
@@ -23,6 +23,8 @@ import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.WindowManager;
+import android.webkit.ConsoleMessage;
+import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.Button;
@@ -273,6 +275,7 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
     webViewAvatar.getSettings().setJavaScriptEnabled(true);
     webViewAvatar.getSettings().setAllowFileAccess(true);
     webViewAvatar.getSettings().setDomStorageEnabled(true);
+    attachWebviewConsoleForward(webViewAvatar);
 
     webViewAvatarTalking = (WebView) findViewById(R.id.avatar_talking_html);
     webViewAvatarTalking.setBackgroundColor(Color.WHITE);
@@ -282,6 +285,7 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
     webViewAvatarTalking.getSettings().setAllowFileAccess(true);
     webViewAvatarTalking.getSettings().setDomStorageEnabled(true);
     webViewAvatarTalking.getSettings().setJavaScriptEnabled(true);
+    attachWebviewConsoleForward(webViewAvatarTalking);
     if (BrekekeUtils.isUserAgentConfig()) {
       webViewAvatar.getSettings().setUserAgentString(BrekekeUtils.userAgentConfig);
       webViewAvatarTalking.getSettings().setUserAgentString(BrekekeUtils.userAgentConfig);
@@ -534,6 +538,9 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
             @Override
             public void onPageStarted(WebView view, String url, Bitmap favicon) {
               super.onPageStarted(view, url, favicon);
+              if (webviewLogEnabled()) {
+                view.evaluateJavascript(webviewConsoleForwardJs, null);
+              }
             }
 
             @Override
@@ -1072,6 +1079,9 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
             public void onPageStarted(WebView view, String url, Bitmap favicon) {
               super.onPageStarted(view, url, favicon);
               vWebViewAvatarTalkingLoading.setVisibility(View.VISIBLE);
+              if (webviewLogEnabled()) {
+                view.evaluateJavascript(webviewConsoleForwardJs, null);
+              }
               if (BrekekeUtils.aiphoneNurseCallEnabled) {
                 view.evaluateJavascript(
                     "window.WebInterface = window.WebInterface || {"
@@ -1613,5 +1623,33 @@ public class IncomingCallActivity extends Activity implements View.OnClickListen
 
   private void error(String k, String d) {
     Emitter.error("IncomingCallActivity " + callerName + " " + k, d);
+  }
+
+  private boolean webviewLogEnabled() {
+    return pbxConfig != null && "true".equals(pbxConfig.optString("webphone.webview.log"));
+  }
+
+  private static final String webviewConsoleForwardJs =
+      "if(!window.__brekekeConsoleForwarded){window.__brekekeConsoleForwarded=true;"
+          + "window.addEventListener('error',function(e){console.error('[WebView] '+(e.message||e)+' '+(e.filename||'')+':'+(e.lineno||''));});"
+          + "window.addEventListener('unhandledrejection',function(e){console.error('[WebView] unhandledrejection: '+((e.reason&&(e.reason.stack||e.reason.message))||e.reason));});}";
+
+  private void attachWebviewConsoleForward(WebView view) {
+    view.setWebChromeClient(
+        new WebChromeClient() {
+          @Override
+          public boolean onConsoleMessage(ConsoleMessage cm) {
+            if (webviewLogEnabled()) {
+              String msg =
+                  "[WebView] " + cm.message() + " (" + cm.sourceId() + ":" + cm.lineNumber() + ")";
+              if (cm.messageLevel() == ConsoleMessage.MessageLevel.ERROR) {
+                Emitter.error(msg);
+              } else {
+                Emitter.debug(msg);
+              }
+            }
+            return true;
+          }
+        });
   }
 }

--- a/src/brekekejs/index.d.ts
+++ b/src/brekekejs/index.d.ts
@@ -453,6 +453,7 @@ export type PbxGetProductInfoRes = {
   'webphone.http.useragent.product': string
   'webphone.error_toast.suppress_enabled': string
   'webphone.error_toast.suppress_patterns': string
+  'webphone.webview.log'?: string
   version: string
 }
 export type PbxGetProductInfoParam = {

--- a/src/components/CustomPageWebView.tsx
+++ b/src/components/CustomPageWebView.tsx
@@ -4,9 +4,11 @@ import type { WebViewMessageEvent, WebViewProps } from 'react-native-webview'
 import WebView from 'react-native-webview'
 import type { WebViewNavigationEvent } from 'react-native-webview/lib/WebViewTypes'
 
+import { webviewInjectConsoleForward } from '#/components/webviewInjectConsoleForward'
 import { webviewInjectSendJsonToRnOnLoad } from '#/components/webviewInjectSendJsonToRnOnLoad'
 import { buildWebViewSource, isAndroid } from '#/config'
 import { ctx } from '#/stores/ctx'
+import { handleWebviewConsoleMessage } from '#/utils/handleWebviewConsoleMessage'
 
 const css = StyleSheet.create({
   image: {
@@ -66,6 +68,9 @@ export const CustomPageWebView = ({
       if (!data) {
         return
       }
+      if (handleWebviewConsoleMessage(data)) {
+        return
+      }
       // check load page 1 time
       if (!nLoading.current) {
         return
@@ -118,11 +123,18 @@ export const CustomPageWebView = ({
     return null
   }
 
+  const consoleForwardJs =
+    ctx.auth.pbxConfig?.['webphone.webview.log'] === 'true'
+      ? webviewInjectConsoleForward
+      : ''
+
   return (
     <WebView
       source={buildWebViewSource(url)}
-      injectedJavaScript={js}
-      injectedJavaScriptBeforeContentLoaded={isAndroid ? js : ''}
+      injectedJavaScript={consoleForwardJs + js}
+      injectedJavaScriptBeforeContentLoaded={
+        consoleForwardJs + (isAndroid ? js : '')
+      }
       style={css.full}
       bounces={false}
       originWhitelist={['*']}

--- a/src/components/SmartImage.tsx
+++ b/src/components/SmartImage.tsx
@@ -6,10 +6,12 @@ import type { WebViewNavigationEvent } from 'react-native-webview/lib/WebViewTyp
 
 import noPhoto from '#/assets/no_photo.png'
 
+import { webviewInjectConsoleForward } from '#/components/webviewInjectConsoleForward'
 import { webviewInjectSendJsonToRnOnLoad } from '#/components/webviewInjectSendJsonToRnOnLoad'
 import { isAndroid } from '#/config'
 import { ctx } from '#/stores/ctx'
 import { checkImageUrl } from '#/utils/checkImageUrl'
+import { handleWebviewConsoleMessage } from '#/utils/handleWebviewConsoleMessage'
 
 const noPhotoImg = typeof noPhoto === 'string' ? { uri: noPhoto } : noPhoto
 
@@ -107,11 +109,14 @@ export const SmartImage = ({
 
   const onMessage = (event: WebViewMessageEvent) => {
     try {
+      const data = event?.nativeEvent?.data
+      if (handleWebviewConsoleMessage(data)) {
+        return
+      }
       // for sure just update load page 1 time
       if (statusImageLoading === StatusImage.loaded) {
         return
       }
-      const data = event?.nativeEvent?.data
       if (!data) {
         return
       }
@@ -154,6 +159,10 @@ export const SmartImage = ({
     (ctx.auth.phoneappliEnabled() && !incoming) || checkImageUrl(uri)
 
   const nocacheUri = useMemo(() => getNoCacheUri(uri), [uri])
+  const consoleForwardJs =
+    ctx.auth.pbxConfig?.['webphone.webview.log'] === 'true'
+      ? webviewInjectConsoleForward
+      : ''
   return (
     <View style={[css.image, style]}>
       {!statusImageLoading && (
@@ -167,9 +176,9 @@ export const SmartImage = ({
         <WebView
           ref={webviewRef}
           source={{ uri }}
-          injectedJavaScript={js}
+          injectedJavaScript={consoleForwardJs + js}
           injectedJavaScriptBeforeContentLoaded={
-            (aiphoneOn ? stubJs : '') + (isAndroid ? js : '')
+            consoleForwardJs + (aiphoneOn ? stubJs : '') + (isAndroid ? js : '')
           }
           style={[css.image, css.full]}
           bounces={false}

--- a/src/components/webviewInjectConsoleForward.ts
+++ b/src/components/webviewInjectConsoleForward.ts
@@ -1,0 +1,44 @@
+export const webviewInjectConsoleForward = `
+(function() {
+  if (window.__brekekeConsoleForwarded) {
+    return;
+  }
+  window.__brekekeConsoleForwarded = true;
+  function fmt(args) {
+    return Array.prototype.map
+      .call(args, function(a) {
+        if (typeof a === 'string') {
+          return a;
+        }
+        try {
+          return JSON.stringify(a);
+        } catch (e) {
+          return String(a);
+        }
+      })
+      .join(' ');
+  }
+  function send(level, msg) {
+    try {
+      window.ReactNativeWebView &&
+        window.ReactNativeWebView.postMessage(
+          JSON.stringify({ __brekekeConsole: { level: level, msg: '[WebView] ' + msg } }),
+        );
+    } catch (e) {}
+  }
+  ['log', 'warn', 'error'].forEach(function(level) {
+    var original = console[level] ? console[level].bind(console) : function() {};
+    console[level] = function() {
+      original.apply(console, arguments);
+      send(level, fmt(arguments));
+    };
+  });
+  window.addEventListener('error', function(e) {
+    send('error', (e.message || e) + ' ' + (e.filename || '') + ':' + (e.lineno || ''));
+  });
+  window.addEventListener('unhandledrejection', function(e) {
+    var reason = e.reason && (e.reason.stack || e.reason.message) ? e.reason.stack || e.reason.message : e.reason;
+    send('error', 'unhandledrejection: ' + reason);
+  });
+})();
+`

--- a/src/utils/handleWebviewConsoleMessage.ts
+++ b/src/utils/handleWebviewConsoleMessage.ts
@@ -1,0 +1,16 @@
+export const handleWebviewConsoleMessage = (data?: string): boolean => {
+  try {
+    if (!data) {
+      return false
+    }
+    const json = JSON.parse(data)
+    const c = json?.__brekekeConsole
+    if (!c) {
+      return false
+    }
+    window.debugStore?.captureConsoleOutput(c.level, c.msg)
+    return true
+  } catch (err) {
+    return false
+  }
+}


### PR DESCRIPTION
﻿﻿﻿⑤ Console log output from content
Route the content's console log output into BrekekePhone's log. Since heavy logging can hurt performance, only output when enabled by a setting. The setting may not exist, so default to "don't output" if no value is read.
   • Proposed setting: webphone.webview.log (true = output, false = don't)